### PR TITLE
Reject Object.prototype originated names

### DIFF
--- a/server/BlacklistAPI.js
+++ b/server/BlacklistAPI.js
@@ -1,6 +1,7 @@
 const db = require("./utils/redis");
 
 const blacklistSet = "blacklisted-packages";
+const objectPrototypes = Object.getOwnPropertyNames(Object.prototype);
 
 function addPackage(packageName) {
   return new Promise((resolve, reject) => {
@@ -52,13 +53,17 @@ function getPackages() {
 
 function includesPackage(packageName) {
   return new Promise((resolve, reject) => {
-    db.sismember(blacklistSet, packageName, (error, value) => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(value === 1);
-      }
-    });
+    if (objectPrototypes.indexOf(packageName) > -1) {
+      reject("Disallowed package name.");
+    } else {
+      db.sismember(blacklistSet, packageName, (error, value) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(value === 1);
+        }
+      });
+    }
   });
 }
 


### PR DESCRIPTION
This PR tries to fix petty error on urls like:
`https://unpkg.com/constructor/`
`https://unpkg.com/hasOwnProperty/`
`https://unpkg.com/valueOf/`

However..

1. dev setup was not easy for me. No access to redis/blacklist. So I couldn't run proper tests for this PR. **It is totally possible that this PR would not be enough.** Fingers crossed.
2. Rejecting `Object.getOwnPropertyNames(Object.prototype)` seems straightforward but there IS one named `[constructor](http://npmjs.com/package/constructor)`. 🤔

Please let me know if there are some bullet points I'm missing. I'm more than glad to fix them.