### PR TITLE
#98 Self Hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,48 @@ Please visit [the UNPKG website](https://unpkg.com) to learn more about how to u
 
 Our sponsors and backers are listed [in SPONSORS.md](SPONSORS.md).
 
+## Private Hosting
+
+Install `unpkg-server` into a local project/folder. Global install is not yet supported.
+
+```sh
+npm i unpkg-server
+```
+
+Start the server:
+
+```sh
+node node_modules/unpkg-server/server.js \
+  --NPM_REGISTRY_URL=https://private-npm-registry.example.org \
+  --PORT=8081
+```
+
+**Caution:** if your registry is using self-signed certificates, you can accept the cert by setting the following flag.
+**Use at your own risk**
+
+`--NODE_TLS_REJECT_UNAUTHORIZED=0`
+
+## CLI Options
+
+These values can be set on the system environment when starting the unpkg `server.js`.
+
+| Flag                   | Options / Description                            | Default value                |
+| ---------------------- | ------------------------------------------------ | ---------------------------- |
+| `NPM_REGISTRY_URL`     | optional - private registry url                  | `https://registry.npmjs.org` |
+| `PORT`                 | optional - port to listen on                     | `8080`                       |
+| `GOOGLE_CLOUD_PROJECT` | The GCP project ID.                              | `null`                       |
+| `GAE_ENV`              | `standard` to enable `@google-cloud/trace-agent` | `null`                       |
+| `DEBUG`                | enableDebugging                                  | `false`                      |
+| `ENABLE_CLOUDFLARE`    | optional `true` or `false`                       | `false`                      |
+| `ORIGIN`               | optional                                         | `https://unpkg.com`          |
+| `CLOUDFLARE_EMAIL`     | optional                                         | `null`                       |
+| `CLOUDFLARE_KEY`       | optional                                         | `null`                       |
+
 ## Build Options
 
 Use a `.env` file to set the following options when building the app with `npm run build`. These values will be bundled into the built `server.js` file.
 
-| Flag               | Options / Description                    | Default value                |
-| ------------------ | ---------------------------------------- | ---------------------------- |
-| `BUILD_ENV`        | `production` or `development`            | `development`                |
-| `NODE_ENV`         | `production`, `staging` or `development` | `development`                |
-| `CLOUDFLARE_EMAIL` | required                                 | `null`                       |
-| `CLOUDFLARE_KEY`   | required                                 | `null`                       |
-| `NPM_REGISTRY_URL` | optional                                 | `https://registry.npmjs.org` |
-| `ORIGIN`           | optional                                 | `https://unpkg.com`          |
-
-## Runtime Options
-
-These values can be set on the system environment when starting the unpkg `server.js`.
-
-| Flag                   | Options / Description                                   | Default value |
-| ---------------------- | ------------------------------------------------------- | ------------- |
-| `GOOGLE_CLOUD_PROJECT` | The GCP project ID associated with your application.    | `null`        |
-| `GAE_ENV`              | Set to `standard` to enable `@google-cloud/trace-agent` | `null`        |
-| `DEBUG`                | enableDebugging                                         | `null`        |
+| Flag        | Options / Description                    | Default value |
+| ----------- | ---------------------------------------- | ------------- |
+| `BUILD_ENV` | `production` or `development`            | `development` |
+| `NODE_ENV`  | `production`, `staging` or `development` | `development` |

--- a/README.md
+++ b/README.md
@@ -8,10 +8,33 @@
 
 [UNPKG](https://unpkg.com) is a fast, global [content delivery network](https://en.wikipedia.org/wiki/Content_delivery_network) for everything on [npm](https://www.npmjs.com/).
 
-### Documentation
+## Documentation
 
 Please visit [the UNPKG website](https://unpkg.com) to learn more about how to use it.
 
-### Sponsors
+## Sponsors
 
 Our sponsors and backers are listed [in SPONSORS.md](SPONSORS.md).
+
+## Build Options
+
+Use a `.env` file to set the following options when building the app with `npm run build`. These values will be bundled into the built `server.js` file.
+
+| Flag               | Options / Description                    | Default value                |
+| ------------------ | ---------------------------------------- | ---------------------------- |
+| `BUILD_ENV`        | `production` or `development`            | `development`                |
+| `NODE_ENV`         | `production`, `staging` or `development` | `development`                |
+| `CLOUDFLARE_EMAIL` | required                                 | `null`                       |
+| `CLOUDFLARE_KEY`   | required                                 | `null`                       |
+| `NPM_REGISTRY_URL` | optional                                 | `https://registry.npmjs.org` |
+| `ORIGIN`           | optional                                 | `https://unpkg.com`          |
+
+## Runtime Options
+
+These values can be set on the system environment when starting the unpkg `server.js`.
+
+| Flag                   | Options / Description                                   | Default value |
+| ---------------------- | ------------------------------------------------------- | ------------- |
+| `GOOGLE_CLOUD_PROJECT` | The GCP project ID associated with your application.    | `null`        |
+| `GAE_ENV`              | Set to `standard` to enable `@google-cloud/trace-agent` | `null`        |
+| `DEBUG`                | enableDebugging                                         | `null`        |

--- a/modules/createServer.js
+++ b/modules/createServer.js
@@ -2,6 +2,7 @@ import cors from 'cors';
 import express from 'express';
 import morgan from 'morgan';
 
+import setEnv from './utils/setEnv';
 import serveDirectoryBrowser from './actions/serveDirectoryBrowser.js';
 import serveDirectoryMetadata from './actions/serveDirectoryMetadata.js';
 import serveFileBrowser from './actions/serveFileBrowser.js';
@@ -20,6 +21,8 @@ import validateFilename from './middleware/validateFilename.js';
 import validatePackagePathname from './middleware/validatePackagePathname.js';
 import validatePackageName from './middleware/validatePackageName.js';
 import validatePackageVersion from './middleware/validatePackageVersion.js';
+
+setEnv();
 
 function createApp(callback) {
   const app = express();
@@ -49,7 +52,10 @@ export default function createServer() {
     app.use(requestLog);
 
     app.get('/', serveMainPage);
-    app.get('/api/stats', serveStats);
+
+    if (process.env.ENABLE_CLOUDFLARE === 'true') {
+      app.get('/api/stats', serveStats);
+    }
 
     app.use(redirectLegacyURLs);
 

--- a/modules/server.js
+++ b/modules/server.js
@@ -1,3 +1,6 @@
+import { version } from '../package.json';
+
+console.log(`unpkg-server v${version}`);
 if (process.env.GAE_ENV === 'standard') {
   require('@google-cloud/trace-agent').start();
 }

--- a/modules/utils/cloudflare.js
+++ b/modules/utils/cloudflare.js
@@ -4,7 +4,10 @@ const cloudflareURL = 'https://api.cloudflare.com/client/v4';
 const cloudflareEmail = process.env.CLOUDFLARE_EMAIL;
 const cloudflareKey = process.env.CLOUDFLARE_KEY;
 
-if (process.env.NODE_ENV !== 'production') {
+if (
+  process.env.NODE_ENV !== 'production' &&
+  process.env.ENABLE_CLOUDFLARE === 'true'
+) {
   if (!cloudflareEmail) {
     throw new Error('Missing the $CLOUDFLARE_EMAIL environment variable');
   }

--- a/modules/utils/npm.js
+++ b/modules/utils/npm.js
@@ -46,11 +46,12 @@ async function fetchPackageInfo(packageName, log) {
 
   log.debug('Fetching package info for %s from %s', packageName, infoURL);
 
-  const { hostname, pathname } = url.parse(infoURL);
+  const { hostname, pathname, port } = url.parse(infoURL);
   const options = {
     agent: agent,
     hostname: hostname,
     path: pathname,
+    port: port || 443,
     headers: {
       Accept: 'application/json'
     }
@@ -173,11 +174,12 @@ export async function getPackage(packageName, version, log) {
 
   log.debug('Fetching package for %s from %s', packageName, tarballURL);
 
-  const { hostname, pathname } = url.parse(tarballURL);
+  const { hostname, pathname, port } = url.parse(tarballURL);
   const options = {
     agent: agent,
     hostname: hostname,
-    path: pathname
+    path: pathname,
+    port: port || 443
   };
 
   const res = await get(options);

--- a/modules/utils/setEnv.js
+++ b/modules/utils/setEnv.js
@@ -1,0 +1,15 @@
+const argv = require('minimist')(process.argv.slice(2));
+
+const { _, ...flags } = argv;
+
+Object.keys(flags || {}).map(key => {
+	const value = flags[key];
+	process.env[key] = value;
+});
+
+process.env.ENABLE_CLOUDFLARE =
+	flags.ENABLE_CLOUDFLARE === 'true' ? true : false;
+
+export default function() {
+	return _;
+}

--- a/modules/utils/setEnv.js
+++ b/modules/utils/setEnv.js
@@ -3,13 +3,13 @@ const argv = require('minimist')(process.argv.slice(2));
 const { _, ...flags } = argv;
 
 Object.keys(flags || {}).map(key => {
-	const value = flags[key];
-	process.env[key] = value;
+  const value = flags[key];
+  process.env[key] = value;
 });
 
 process.env.ENABLE_CLOUDFLARE =
-	flags.ENABLE_CLOUDFLARE === 'true' ? true : false;
+  flags.ENABLE_CLOUDFLARE === 'true' ? true : false;
 
 export default function() {
-	return _;
+  return _;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpkg-server",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": false,
   "description": "The CDN for everything on npm",
   "main": "server.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
-  "name": "unpkg",
-  "private": true,
+  "name": "unpkg-server",
+  "version": "0.0.0",
+  "private": false,
   "description": "The CDN for everything on npm",
+  "main": "server.js",
+  "files": [
+    "server.js"
+  ],
   "scripts": {
     "build": "rollup -c",
     "clean": "git clean -e '!/.env' -fdX .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpkg-server",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": false,
   "description": "The CDN for everything on npm",
   "main": "server.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unpkg-server",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": false,
   "description": "The CDN for everything on npm",
   "main": "server.js",
@@ -36,6 +36,7 @@
     "jsesc": "^2.5.2",
     "lru-cache": "^5.1.1",
     "mime": "^2.4.0",
+    "minimist": "^1.2.0",
     "morgan": "^1.9.1",
     "ndjson": "^1.5.0",
     "pretty-bytes": "^5.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -80,16 +80,6 @@ const server = {
       limit: 5 * 1024,
       publicPath: '/_client/',
       emitFiles: false
-    }),
-    replace({
-      'process.env.CLOUDFLARE_EMAIL': JSON.stringify(
-        process.env.CLOUDFLARE_EMAIL
-      ),
-      'process.env.CLOUDFLARE_KEY': JSON.stringify(process.env.CLOUDFLARE_KEY),
-      'process.env.NPM_REGISTRY_URL': JSON.stringify(
-        process.env.NPM_REGISTRY_URL
-      ),
-      'process.env.ORIGIN': JSON.stringify(process.env.ORIGIN)
     })
   ]
 };

--- a/scripts/utils/cloudflare.js
+++ b/scripts/utils/cloudflare.js
@@ -3,14 +3,16 @@ const fetch = require('isomorphic-fetch');
 const CloudflareEmail = process.env.CLOUDFLARE_EMAIL;
 const CloudflareKey = process.env.CLOUDFLARE_KEY;
 
-if (CloudflareEmail == null) {
-  console.error('Missing the $CLOUDFLARE_EMAIL environment variable');
-  process.exit(1);
-}
+if (process.env.ENABLE_CLOUDFLARE === 'true') {
+  if (CloudflareEmail == null) {
+    console.error('Missing the $CLOUDFLARE_EMAIL environment variable');
+    process.exit(1);
+  }
 
-if (CloudflareKey == null) {
-  console.error('Missing the $CLOUDFLARE_KEY environment variable');
-  process.exit(1);
+  if (CloudflareKey == null) {
+    console.error('Missing the $CLOUDFLARE_KEY environment variable');
+    process.exit(1);
+  }
 }
 
 function get(path) {
@@ -24,8 +26,8 @@ function get(path) {
 }
 
 function getLog(zoneId, rayId) {
-  return get(`/zones/${zoneId}/logs/requests/${rayId}`).then(
-    res => (res.status === 404 ? null : res.json())
+  return get(`/zones/${zoneId}/logs/requests/${rayId}`).then(res =>
+    res.status === 404 ? null : res.json()
   );
 }
 


### PR DESCRIPTION
I've published a #98 **Self Hosting** version of unpkg to npm here:
https://www.npmjs.com/package/unpkg-server

I've been running it in my own organisation against a private npm registry (nexus) and it seems pretty stable.

These are the changes I used to produce a version of `server.js` that can be configured using a few CLI flags.

I've changed the build process a bit which I'm sure would break the unpkg build process, so this PR is primarily to discuss the approach and what would need to change before this could potentially be merged.

* Added a flag to disable the integration with cloudflare: `ENABLE_CLOUDFLARE `
* Moved several `process.env` options to be read at runtime instead of at build time
* Added a CLI library **minimist** for reading/setting config flags
* Documented the available configuration options
* Support for ports other than **443**
* Updated `package.json` to support publishing to npm