### PR TITLE
Leverage `renderToNodeStream`

### DIFF
--- a/modules/actions/serveBrowsePage.js
+++ b/modules/actions/serveBrowsePage.js
@@ -1,11 +1,11 @@
-import { renderToString, renderToStaticMarkup } from 'react-dom/server';
+import { renderToNodeStream } from 'react-dom/server';
 import semver from 'semver';
 
 import BrowseApp from '../client/browse/App.js';
 import MainTemplate from '../templates/MainTemplate.js';
 import asyncHandler from '../utils/asyncHandler.js';
 import getScripts from '../utils/getScripts.js';
-import { createElement, createHTML } from '../utils/markup.js';
+import { createElement } from '../utils/markup.js';
 import { getVersionsAndTags } from '../utils/npm.js';
 
 const doctype = '<!DOCTYPE html>';
@@ -43,27 +43,27 @@ async function serveBrowsePage(req, res) {
     filename: req.filename,
     target: req.browseTarget
   };
-  const content = createHTML(renderToString(createElement(BrowseApp, data)));
+  const content = createElement(BrowseApp, data);
   const elements = getScripts('browse', 'iife', globalURLs);
 
-  const html =
-    doctype +
-    renderToStaticMarkup(
-      createElement(MainTemplate, {
-        title: `UNPKG - ${req.packageName}`,
-        description: `The CDN for ${req.packageName}`,
-        data,
-        content,
-        elements
-      })
-    );
-
-  res
-    .set({
-      'Cache-Control': 'public, max-age=14400', // 4 hours
-      'Cache-Tag': 'browse'
+  const stream = renderToNodeStream(
+    createElement(MainTemplate, {
+      title: `UNPKG - ${req.packageName}`,
+      description: `The CDN for ${req.packageName}`,
+      data,
+      content,
+      elements
     })
-    .send(html);
+  );
+
+  res.set({
+    'Cache-Control': 'public, max-age=14400', // 4 hours
+    'Cache-Tag': 'browse'
+  });
+
+  res.write(doctype);
+
+  stream.pipe(res);
 }
 
 export default asyncHandler(serveBrowsePage);

--- a/modules/actions/serveBrowsePage.js
+++ b/modules/actions/serveBrowsePage.js
@@ -57,6 +57,7 @@ async function serveBrowsePage(req, res) {
   );
 
   res.set({
+    'Content-Type': 'text/html',
     'Cache-Control': 'public, max-age=14400', // 4 hours
     'Cache-Tag': 'browse'
   });

--- a/modules/templates/MainTemplate.js
+++ b/modules/templates/MainTemplate.js
@@ -53,7 +53,7 @@ gtag('config', 'UA-140352188-1');`),
     e(
       'body',
       null,
-      e('div', { id: 'root', dangerouslySetInnerHTML: content }),
+      e('div', { id: 'root' }, content),
       ...elements
     )
   );

--- a/modules/templates/MainTemplate.js
+++ b/modules/templates/MainTemplate.js
@@ -47,13 +47,13 @@ gtag('config', 'UA-140352188-1');`),
       favicon && e('link', { rel: 'shortcut icon', href: favicon }),
       e('title', null, title),
       x(promiseShim),
-      x(fetchShim),
-      data && x(`window.__DATA__ = ${encodeJSONForScript(data)}`)
+      x(fetchShim)
     ),
     e(
       'body',
       null,
       e('div', { id: 'root' }, content),
+      data && x(`window.__DATA__ = ${encodeJSONForScript(data)}`),
       ...elements
     )
   );


### PR DESCRIPTION
Continued from #218, we decided to go with `renderToNodeStream` first since there might be client side features in the future.

The following benchmark is run on my macbook pro (2018, 2.7GHz i7, macOS 10.14.6) on page `unpkg.com/browse/typescript@3.6.3/lib/tsc.js` (Network throttle Fast 4G) under production mode.

`renderToStaticMarkup` + `renderToString` | `renderToNodeStream` + moving `__DATA__` to body
--- | ---
![image](https://user-images.githubusercontent.com/7753001/66096975-4d564080-e5cf-11e9-8393-005e8cffc1a3.png) | ![image](https://user-images.githubusercontent.com/7753001/66097018-6f4fc300-e5cf-11e9-80de-b0275f485c05.png)


You can see that the **TTFB** is lower (`3.94s` to `1.91s`) than the current one in a fairly heavy page.

It's not a huge deal though, since it only matters in the first request, requests after that should be cached either by browser or by cloudflare. However, we can reduce some overhead (CPU, memory) for our server when lots of files are being requested for the first time in a short interval.