### PR TITLE
chore: add a failing test for dynamic imports with "`"

### DIFF
--- a/modules/plugins/__tests__/unpkgRewrite-test.js
+++ b/modules/plugins/__tests__/unpkgRewrite-test.js
@@ -61,6 +61,10 @@ const testCases = [
     after: 'import("./something.js?module");'
   },
   {
+    before: 'import(`./something.js`);',
+    after: 'import(`./something.js?module`);'
+  },
+  {
     before: 'import("react");',
     after: 'import("https://unpkg.com/react@15.6.1?module");'
   }


### PR DESCRIPTION
Failing Test for https://github.com/mjackson/unpkg/issues/253