### PR TITLE
Show the line numbers fixed-width.

### DIFF
--- a/modules/client/browse/FileViewer.js
+++ b/modules/client/browse/FileViewer.js
@@ -57,6 +57,7 @@ function CodeListing({ highlights }) {
                     paddingRight: 10,
                     color: 'rgba(27,31,35,.3)',
                     textAlign: 'right',
+                    fontVariant: 'tabular-nums',
                     verticalAlign: 'top',
                     width: '1%',
                     minWidth: 50,


### PR DESCRIPTION
Apply font-variant tabular-nums to the line numbers to show them in a fixed width. This makes the line-numbers easier to scan and less jumpy.

https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant