### PR TITLE
upgrade mime for improved CJS handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "isomorphic-fetch": "^2.2.1",
     "jsesc": "^2.5.2",
     "lru-cache": "^5.1.1",
-    "mime": "^2.4.0",
+    "mime": "^2.6.0",
     "morgan": "^1.9.1",
     "ndjson": "^1.5.0",
     "pretty-bytes": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4616,10 +4616,15 @@ mime@1.6.0, mime@^1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.3.1, mime@^2.4.0:
+mime@^2.3.1:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.3.tgz#229687331e86f68924e6cb59e1cdd937f18275fe"
   integrity sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==
+
+mime@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
+  integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
 mimic-fn@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
`.cjs` is being served as `text/plain`, which is incorrect. This PR upgrades the `mime` package as this is fixed in newer versions of it. See https://github.com/mjackson/unpkg/issues/355#issuecomment-1541520209