### PR TITLE
redirect to browserDirectory when the url does not contains filename

### DIFF
--- a/modules/__tests__/browseFile-test.js
+++ b/modules/__tests__/browseFile-test.js
@@ -8,6 +8,18 @@ describe('A request to browse a file', () => {
     server = createServer();
   });
 
+  describe('when the URL does not contains filename', () => {
+    it('redirects to browseDirectory', done => {
+      request(server)
+        .get('/browse/react@16.8.0')
+        .end((err, res) => {
+          expect(res.statusCode).toBe(302);
+          expect(res.headers['location']).toBe('/browse/react@16.8.0/');
+          done();
+        });
+    });
+  });
+
   describe('when the file exists', () => {
     it('returns an HTML page', done => {
       request(server)

--- a/modules/actions/serveFileBrowser.js
+++ b/modules/actions/serveFileBrowser.js
@@ -54,6 +54,11 @@ async function findEntry(stream, filename) {
 
 async function serveFileBrowser(req, res) {
   const stream = await getPackage(req.packageName, req.packageVersion, req.log);
+
+  if (!req.filename) {
+    return res.redirect(req.originalUrl + '/')
+  }
+
   const entry = await findEntry(stream, req.filename);
 
   if (!entry) {


### PR DESCRIPTION
redirect to browserDirectory when the url does not contains filename

example:

http://127.0.0.1:8080/browse/react


Before:

<img width="1443" alt="image" src="https://github.com/mjackson/unpkg/assets/1265888/e0db6799-bd64-4729-be5d-ea291484a8ad">

After:

<img width="1346" alt="image" src="https://github.com/mjackson/unpkg/assets/1265888/00de35e1-577f-4161-b28e-b7877521f712">
