### PR TITLE
Fix broken example link for "omit the version/tag entirely"

### DIFF
--- a/modules/client/main/App.js
+++ b/modules/client/main/App.js
@@ -193,8 +193,8 @@ export default function App() {
               </Link>
             </li>
             <li>
-              <Link href="/react/umd/react.production.min.js">
-                unpkg.com/react/umd/react.production.min.js
+              <Link href="/react/index.js">
+                unpkg.com/react/index.js
               </Link>
             </li>
           </ul>


### PR DESCRIPTION
The "or omit the version/tag entirely" section on your website has an example, which shows why exactly this is maybe not the best idea :wink: respectively the link broke.

Because it ends up as https://unpkg.com/react@19.0.0/umd/react.production.min.js, which currently just shows a 404:
> Cannot find "/umd/react.production.min.js" in react@19.0.0

As such, to keep the example intact I just used a different file, which works even in the current React version: https://unpkg.com/react@19.0.0/index.js