### PR TITLE
Add CI workflow and Bun runtime contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+          run_install: false
+
+      - name: Set up Node for tooling
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Set up Bun runtime
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Test packages
+        run: pnpm -r test

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "unpkg-dev",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.15.0",
   "engines": {
-    "node": ">=23"
+    "bun": ">=1.2.8"
   },
   "scripts": {
     "build": "pnpm -r run build",

--- a/packages/unpkg-app/package.json
+++ b/packages/unpkg-app/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "build": "wrangler deploy --dry-run --outdir=dist",
-    "build:assets": "node --disable-warning=ExperimentalWarning ../../scripts/build-assets.ts",
+    "build:assets": "bun ../../scripts/build-assets.ts",
     "dev": "wrangler dev --env dev --port 3001",
     "dev:assets": "bun ../../scripts/serve-assets.ts",
     "test": "bun --preload=./test/setup.ts test",

--- a/packages/unpkg-www/package.json
+++ b/packages/unpkg-www/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "wrangler deploy --dry-run --outdir=dist",
-    "build:assets": "node --disable-warning=ExperimentalWarning ../../scripts/build-assets.ts",
+    "build:assets": "bun ../../scripts/build-assets.ts",
     "dev": "wrangler dev --env dev --port 3000",
     "dev:assets": "bun ../../scripts/serve-assets.ts",
     "test": "bun --preload=./test/setup.ts test",


### PR DESCRIPTION
This adds a baseline GitHub Actions workflow for the repo and makes the intended runtime/tooling split explicit: Bun is the project runtime for scripts and tests, while Node is only installed in CI to host Node-based tooling like pnpm, TypeScript, and Wrangler.

- Adds CI on pushes to main, PRs targeting main, and manual workflow dispatches.
- Pins pnpm and Bun versions in CI, with Node 24 available only for tooling.
- Updates app asset builds to run through Bun instead of invoking Node directly.
- Declares the repo package manager and Bun engine in the root package metadata.
