### PR TITLE
Strengthen esm.sh redirect and export parity

### DIFF
--- a/packages/unpkg-esm/src/request-handler.test.ts
+++ b/packages/unpkg-esm/src/request-handler.test.ts
@@ -50,6 +50,12 @@ describe("handleRequest", () => {
       let url = new URL(request.url);
 
       if (url.origin === env.FILES_ORIGIN) {
+        if (url.pathname === "/file/@babel/runtime@7.26.0/helpers/extends.js") {
+          return new Response("export default Object.assign;\n", {
+            headers: { "Content-Type": "application/javascript" },
+          });
+        }
+
         if (url.pathname === "/file/normalize.css@8.0.1/normalize.css") {
           return new Response("html { line-height: 1.15; }\n", {
             headers: {
@@ -73,6 +79,34 @@ describe("handleRequest", () => {
                 name: "normalize.css",
                 version: "8.0.1",
                 main: "normalize.css",
+              },
+            },
+          });
+        case "https://registry.npmjs.org/bootstrap":
+          return Response.json({
+            name: "bootstrap",
+            "dist-tags": { latest: "5.3.8" },
+            versions: {
+              "5.3.8": {
+                name: "bootstrap",
+                version: "5.3.8",
+                main: "dist/js/bootstrap.js",
+                module: "dist/js/bootstrap.esm.js",
+                style: "dist/css/bootstrap.css",
+              },
+            },
+          });
+        case "https://registry.npmjs.org/@babel/runtime":
+          return Response.json({
+            name: "@babel/runtime",
+            "dist-tags": { latest: "7.26.0" },
+            versions: {
+              "7.26.0": {
+                name: "@babel/runtime",
+                version: "7.26.0",
+                exports: {
+                  "./helpers/*": "./helpers/*.js",
+                },
               },
             },
           });
@@ -263,11 +297,87 @@ describe("handleRequest", () => {
     expect(await response.text()).toMatch(/"name": "react"/);
   });
 
+  it("redirects raw package roots to their import entry", async () => {
+    let reactResponse = await dispatchFetch("https://esm.unpkg.com/react@18.2.0?raw=", {
+      redirect: "manual",
+    });
+    expect(reactResponse.status).toBe(301);
+    expect(reactResponse.headers.get("Location")).toBe("/react@18.2.0/index.js?raw=");
+
+    let preactResponse = await dispatchFetch("https://esm.unpkg.com/preact@10.26.4?raw=", {
+      redirect: "manual",
+    });
+    expect(preactResponse.status).toBe(301);
+    expect(preactResponse.headers.get("Location")).toBe("/preact@10.26.4/dist/preact.mjs?raw=");
+  });
+
+  it("redirects raw exported subpaths to their source asset", async () => {
+    let response = await dispatchFetch("https://esm.unpkg.com/react@18.2.0/jsx-runtime?raw=", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("/react@18.2.0/jsx-runtime.js?raw=");
+  });
+
+  it("resolves extensionless raw subpaths when export patterns are unavailable", async () => {
+    let response = await dispatchFetch("https://esm.unpkg.com/@babel/runtime@7.26.0/helpers/extends?raw=", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("/@babel/runtime@7.26.0/helpers/extends.js?raw=");
+  });
+
+  it("prefers a package module entry over an unrelated stylesheet for raw requests", async () => {
+    let response = await dispatchFetch("https://esm.unpkg.com/bootstrap@5.3.8?raw=", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("/bootstrap@5.3.8/dist/js/bootstrap.esm.js?raw=");
+  });
+
   it("redirects CSS package roots to their stylesheet entry", async () => {
     let response = await dispatchFetch("https://esm.unpkg.com/normalize.css@8.0.1", {
       redirect: "manual",
     });
 
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("/normalize.css@8.0.1/normalize.css");
+  });
+
+  it("strips irrelevant build queries when redirecting CSS package roots", async () => {
+    let response = await dispatchFetch("https://esm.unpkg.com/normalize.css@8.0.1?target=es2020", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("/normalize.css@8.0.1/normalize.css");
+  });
+
+  it("preserves module mode when redirecting CSS package roots", async () => {
+    let normalizedResponse = await dispatchFetch("https://esm.unpkg.com/normalize.css@8.0.1?module", {
+      redirect: "manual",
+    });
+    expect(normalizedResponse.status).toBe(301);
+
+    let response = await dispatchFetch(`https://esm.unpkg.com${normalizedResponse.headers.get("Location")}`, {
+      redirect: "manual",
+    });
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("/normalize.css@8.0.1/normalize.css?module=");
+  });
+
+  it("redirects raw CSS package roots to their stylesheet entry", async () => {
+    let normalizedResponse = await dispatchFetch("https://esm.unpkg.com/normalize.css@8.0.1?raw", {
+      redirect: "manual",
+    });
+    expect(normalizedResponse.status).toBe(301);
+
+    let response = await dispatchFetch(`https://esm.unpkg.com${normalizedResponse.headers.get("Location")}`, {
+      redirect: "manual",
+    });
     expect(response.status).toBe(301);
     expect(response.headers.get("Location")).toBe("/normalize.css@8.0.1/normalize.css");
   });
@@ -304,12 +414,9 @@ describe("handleRequest", () => {
   });
 
   it("serves declaration files without building them", async () => {
-    let redirectResponse = await dispatchFetch("https://esm.unpkg.com/preact@10.26.4/src/index.d.ts", {
+    let response = await dispatchFetch("https://esm.unpkg.com/preact@10.26.4/src/index.d.ts", {
       redirect: "manual",
     });
-    expect(redirectResponse.status).toBe(301);
-
-    let response = await dispatchFetch(`https://esm.unpkg.com${redirectResponse.headers.get("Location")}`);
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/typescript; charset=utf-8");
     expect(await response.text()).toContain("export as namespace preact");
@@ -327,6 +434,15 @@ describe("handleRequest", () => {
     expect(response.status).toBe(301);
     expect(response.headers.get("Location")).toBe("/@types/react@18.2.0/index.d.ts");
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=60, s-maxage=300");
+  });
+
+  it("strips build queries when redirecting types-only packages to declarations", async () => {
+    let response = await dispatchFetch("https://esm.unpkg.com/@types/react@18.2.0?target=es2020", {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get("Location")).toBe("/@types/react@18.2.0/index.d.ts");
   });
 
   it("returns module worker wrappers", async () => {
@@ -380,6 +496,22 @@ describe("handleRequest", () => {
 });
 
 describe("resolveTypesPath", () => {
+  it("uses the declared root types path instead of applying a typesVersions wildcard to an empty subpath", () => {
+    expect(
+      resolveTypesPath(
+        {
+          types: "index.d.ts",
+          typesVersions: {
+            "<=5.6": {
+              "*": ["ts5.6/*"],
+            },
+          },
+        },
+        "."
+      )
+    ).toBe("index.d.ts");
+  });
+
   it("resolves declaration paths from typesVersions", () => {
     expect(
       resolveTypesPath(

--- a/packages/unpkg-esm/src/request-handler.ts
+++ b/packages/unpkg-esm/src/request-handler.ts
@@ -162,13 +162,29 @@ export async function handleRequest(request: Request, env: Env, context: Executi
   }
 
   if (searchParams.has("raw")) {
-    return serveRawFile(env, packageName, version, packagePath.filename ?? "/package.json");
+    let rawPath = await resolveRawPath(env, packageName, version, packageJson, packagePath.filename);
+    if (packagePath.filename !== rawPath) {
+      let rawSearch = isCssPath(rawPath) ? "" : search;
+      return redirect(`/${packageName}@${version}${rawPath}${rawSearch}`, {
+        status: 301,
+        headers: corsHeaders({
+          "Cache-Control": moduleCacheControl,
+        }),
+      });
+    }
+
+    return serveRawFile(env, packageName, version, rawPath);
   }
 
   let cssPath = resolveCssPath(packageJson, packagePath.filename);
   if (cssPath != null) {
     if (packagePath.filename !== cssPath) {
-      return redirect(`/${packageName}@${version}${cssPath}${search}`, {
+      let cssSearchParams = new URLSearchParams();
+      if (searchParams.has("module")) {
+        cssSearchParams.set("module", searchParams.get("module") ?? "");
+      }
+
+      return redirect(`/${packageName}@${version}${cssPath}${normalizeSearch(cssSearchParams)}`, {
         status: 301,
         headers: corsHeaders({
           "Cache-Control": moduleCacheControl,
@@ -180,6 +196,7 @@ export async function handleRequest(request: Request, env: Env, context: Executi
       ? serveCssModule(env, packageName, version, cssPath)
       : serveRawFile(env, packageName, version, cssPath);
   }
+
   if (searchParams.has("css")) {
     return jsonError({
       code: "CSS_NOT_FOUND",
@@ -403,6 +420,52 @@ function resolveCssPath(packageJson: PackageJson, filename: string | undefined):
   return null;
 }
 
+async function resolveRawPath(
+  env: Env,
+  packageName: string,
+  version: string,
+  packageJson: PackageJson,
+  filename: string | undefined
+): Promise<string> {
+  let resolved: string;
+  if (filename != null && filename !== "/") {
+    resolved =
+      resolvePackageExport(packageJson, filename, {
+        conditions: ["import", "module", "default"],
+        useBrowserField: false,
+        useModuleField: packageJson.exports == null,
+      }) ?? filename;
+  } else {
+    resolved =
+      resolvePackageExport(packageJson, "/", {
+        conditions: ["import", "module", "default"],
+        useBrowserField: false,
+        useModuleField: packageJson.exports == null,
+      }) ?? "/index.js";
+  }
+
+  if (hasFileExtension(resolved)) {
+    return resolved;
+  }
+
+  for (let candidate of [`${resolved}.js`, `${resolved}.mjs`, `${resolved}.cjs`, `${resolved.replace(/\/+$/, "")}/index.js`]) {
+    if (await rawFileExists(env, packageName, version, candidate)) {
+      return candidate;
+    }
+  }
+
+  return resolved;
+}
+
+async function rawFileExists(env: Env, packageName: string, version: string, filename: string): Promise<boolean> {
+  let response = await fetch(new URL(`/file/${packageName}@${version}${filename}`, env.FILES_ORIGIN));
+  return response.ok;
+}
+
+function hasFileExtension(filename: string): boolean {
+  return /\.[^/]+$/.test(filename);
+}
+
 function getPackageJsonString(packageJson: PackageJson, key: string): string | undefined {
   let value = (packageJson as PackageJson & Record<string, unknown>)[key];
   return typeof value === "string" ? value : undefined;
@@ -443,6 +506,10 @@ export function resolveTypesPath(packageJson: PackageJson, subpath: string): str
     if (resolved != null) {
       return resolved;
     }
+  }
+
+  if (subpath === ".") {
+    return packageJson.types ?? packageJson.typings ?? null;
   }
 
   let typesVersionsPath = resolveTypesVersionsPath(packageJson, subpath);

--- a/packages/unpkg-files/Dockerfile
+++ b/packages/unpkg-files/Dockerfile
@@ -1,7 +1,5 @@
 # syntax = docker/dockerfile:1
 
-FROM denoland/deno:bin-2.9.4 AS deno
-
 # Use Node.js for the build image
 FROM node:23.6.0-slim AS build
 WORKDIR /app
@@ -36,8 +34,6 @@ RUN pnpm --filter unpkg-files deploy --prod dist-files
 FROM oven/bun:1.2.8
 LABEL fly_launch_runtime="Bun"
 WORKDIR /app
-
-COPY --from=deno /deno /usr/local/bin/deno
 
 ENV DEBUG=1
 

--- a/packages/unpkg-files/Dockerfile
+++ b/packages/unpkg-files/Dockerfile
@@ -1,5 +1,7 @@
 # syntax = docker/dockerfile:1
 
+FROM denoland/deno:bin-2.9.4 AS deno
+
 # Use Node.js for the build image
 FROM node:23.6.0-slim AS build
 WORKDIR /app
@@ -34,6 +36,8 @@ RUN pnpm --filter unpkg-files deploy --prod dist-files
 FROM oven/bun:1.2.8
 LABEL fly_launch_runtime="Bun"
 WORKDIR /app
+
+COPY --from=deno /deno /usr/local/bin/deno
 
 ENV DEBUG=1
 

--- a/packages/unpkg-files/package.json
+++ b/packages/unpkg-files/package.json
@@ -11,6 +11,7 @@
     "dist"
   ],
   "dependencies": {
+    "@esm.sh/cjs-module-lexer": "1.1.0",
     "chalk": "^5.4.1",
     "es-module-lexer": "^1.6.0",
     "esbuild": "^0.24.2",

--- a/packages/unpkg-files/src/esm-sh-cjs-module-lexer.d.ts
+++ b/packages/unpkg-files/src/esm-sh-cjs-module-lexer.d.ts
@@ -1,0 +1,13 @@
+declare module "@esm.sh/cjs-module-lexer" {
+  export interface CommonJsLexerOptions {
+    callMode?: boolean;
+    nodeEnv?: "development" | "production";
+  }
+
+  export interface CommonJsLexerResult {
+    exports: string[];
+    reexports: string[];
+  }
+
+  export function parse(filename: string, code: string, options?: CommonJsLexerOptions): CommonJsLexerResult;
+}

--- a/packages/unpkg-files/src/lib/esm-build-service.test.ts
+++ b/packages/unpkg-files/src/lib/esm-build-service.test.ts
@@ -402,6 +402,31 @@ describe("bundleSource", () => {
     }
   });
 
+  it("does not leak dependency exports when the CommonJS entry declares its own surface", async () => {
+    let packageDirectory = await mkdtemp(path.join(tmpdir(), "unpkg-esm-bundled-cjs-private-exports-"));
+
+    try {
+      await writeFile(
+        path.join(packageDirectory, "root.js"),
+        "exports.createRoot = () => 'ok'; exports.privateInternal = true;"
+      );
+      let result = await bundleSource(
+        packageDirectory,
+        { name: "bundled-cjs-private-exports-package" },
+        "bundled-cjs-private-exports-package",
+        "1.0.0",
+        "/client.js",
+        "var root = require('./root.js'); exports.createRoot = root.createRoot;",
+        options()
+      );
+
+      expect(result.code).toContain("export const createRoot = __unpkg_cjs_default.createRoot;");
+      expect(result.code).not.toContain("export const privateInternal");
+    } finally {
+      await rm(packageDirectory, { force: true, recursive: true });
+    }
+  });
+
   it("adds named exports from CommonJS object exports", async () => {
     let result = await transformSource(
       "const camelCase = () => 'ok'; module.exports = { camelCase, forEach: function () { return { nested: true }; } };",

--- a/packages/unpkg-files/src/lib/esm-build-service.test.ts
+++ b/packages/unpkg-files/src/lib/esm-build-service.test.ts
@@ -5,10 +5,12 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 
 import {
+  analyzeCommonJsSource,
   bundleSource,
   normalizeBuildOptions,
   parseAliases,
   parseDependencyOverrides,
+  parseSelectedExports,
   resolveBuildFilename,
   rewriteEsmImports,
   transformSource,
@@ -32,6 +34,53 @@ describe("parseAliases", () => {
       react: "preact/compat",
       "react-dom": "preact/compat",
     });
+  });
+});
+
+describe("parseSelectedExports", () => {
+  it("normalizes valid unique export names", () => {
+    expect(parseSelectedExports("render, h,render,default,not-valid!,class")).toEqual(["default", "h", "render"]);
+  });
+});
+
+describe("analyzeCommonJsSource", () => {
+  it("tracks properties assigned through a module.exports alias", () => {
+    let result = analyzeCommonJsSource(
+      "/process.js",
+      "var process = module.exports = {}; process.cwd = function () {}; process.env = {};",
+      "production"
+    );
+
+    expect(result.exports).toEqual(["cwd", "env"]);
+  });
+
+  it("tracks properties on exported functions and objects", () => {
+    let functionResult = analyzeCommonJsSource(
+      "/events.js",
+      "function EventEmitter() {} module.exports = EventEmitter; EventEmitter.EventEmitter = EventEmitter; EventEmitter.listenerCount = function () {};",
+      "production"
+    );
+    let objectResult = analyzeCommonJsSource(
+      "/path.js",
+      "var posix = { resolve: function () {}, sep: '/' }; posix.posix = posix; module.exports = posix;",
+      "production"
+    );
+
+    expect(functionResult.exports).toEqual(["EventEmitter", "listenerCount"]);
+    expect(objectResult.exports).toEqual(["resolve", "sep", "posix"]);
+  });
+
+  it("selects conditional reexports using the active environment", () => {
+    let code = [
+      "if (process.env.NODE_ENV === 'production') {",
+      "  module.exports = require('./production.js');",
+      "} else {",
+      "  module.exports = require('./development.js');",
+      "}",
+    ].join("\n");
+
+    expect(analyzeCommonJsSource("/index.js", code, "production").reexports).toEqual(["./production.js"]);
+    expect(analyzeCommonJsSource("/index.js", code, "development").reexports).toEqual(["./development.js"]);
   });
 });
 
@@ -273,8 +322,22 @@ describe("transformSource", () => {
       options()
     );
 
-    expect(result.code).toContain("export { __unpkg_cjs_default as default };");
-    expect(result.code).toContain("export const answer = __unpkg_cjs_default.answer;");
+    expect(result.code).toContain("__unpkg_cjs_default as default");
+    expect(result.code).toContain('__unpkg_cjs_default["answer"]');
+    expect(result.code).toContain("as answer");
+  });
+
+  it("aliases named exports without shadowing globals used by CommonJS source", async () => {
+    let result = await transformSource(
+      "exports.parseInt = parseInt; exports.setTimeout = setTimeout;",
+      "/src/index.cjs",
+      options()
+    );
+
+    expect(result.code).not.toContain("const parseInt =");
+    expect(result.code).not.toContain("const setTimeout =");
+    expect(result.code).toContain("as parseInt");
+    expect(result.code).toContain("as setTimeout");
   });
 
   it("rejects dynamic require with a clear diagnostic", async () => {
@@ -315,6 +378,29 @@ describe("transformSource", () => {
 });
 
 describe("bundleSource", () => {
+  it("tree-shakes ESM builds to selected exports", async () => {
+    let packageDirectory = await mkdtemp(path.join(tmpdir(), "unpkg-esm-selected-exports-"));
+
+    try {
+      let code = "export const foo = 'foo'; export const bar = 'bar';";
+      await writeFile(path.join(packageDirectory, "index.js"), code);
+      let result = await bundleSource(
+        packageDirectory,
+        { name: "selected-exports-package" },
+        "selected-exports-package",
+        "1.0.0",
+        "/index.js",
+        code,
+        options("exports=foo")
+      );
+
+      expect(result.code).toContain("foo");
+      expect(result.code).not.toContain("bar");
+    } finally {
+      await rm(packageDirectory, { force: true, recursive: true });
+    }
+  });
+
   it("bundles package self-references as package-internal imports", async () => {
     let packageDirectory = await mkdtemp(path.join(tmpdir(), "unpkg-esm-self-reference-"));
 
@@ -353,8 +439,9 @@ describe("bundleSource", () => {
 
       expect(result.code).not.toContain('Dynamic require of "self-referencing-package"');
       expect(result.code).toContain("createRoot");
-      expect(result.code).toContain("export { __unpkg_cjs_default as default };");
-      expect(result.code).toContain("export const createRoot = __unpkg_cjs_default.createRoot;");
+      expect(result.code).toContain("__unpkg_cjs_default as default");
+      expect(result.code).toContain('__unpkg_cjs_default["createRoot"]');
+      expect(result.code).toContain("as createRoot");
     } finally {
       await rm(packageDirectory, { force: true, recursive: true });
     }
@@ -396,7 +483,8 @@ describe("bundleSource", () => {
         options()
       );
 
-      expect(result.code).toContain("export const createContext = __unpkg_cjs_default.createContext;");
+      expect(result.code).toContain('__unpkg_cjs_default["createContext"]');
+      expect(result.code).toContain("as createContext");
     } finally {
       await rm(packageDirectory, { force: true, recursive: true });
     }
@@ -420,8 +508,9 @@ describe("bundleSource", () => {
         options()
       );
 
-      expect(result.code).toContain("export const createRoot = __unpkg_cjs_default.createRoot;");
-      expect(result.code).not.toContain("export const privateInternal");
+      expect(result.code).toContain('__unpkg_cjs_default["createRoot"]');
+      expect(result.code).toContain("as createRoot");
+      expect(result.code).not.toContain('unpkg_cjs_default["privateInternal"]');
     } finally {
       await rm(packageDirectory, { force: true, recursive: true });
     }
@@ -434,8 +523,10 @@ describe("bundleSource", () => {
       options()
     );
 
-    expect(result.code).toContain("export const camelCase = __unpkg_cjs_default.camelCase;");
-    expect(result.code).toContain("export const forEach = __unpkg_cjs_default.forEach;");
+    expect(result.code).toContain('__unpkg_cjs_default["camelCase"]');
+    expect(result.code).toContain("as camelCase");
+    expect(result.code).toContain('__unpkg_cjs_default["forEach"]');
+    expect(result.code).toContain("as forEach");
   });
 
   it("preserves ESM dependency re-exports as external ESM", async () => {

--- a/packages/unpkg-files/src/lib/esm-build-service.ts
+++ b/packages/unpkg-files/src/lib/esm-build-service.ts
@@ -391,10 +391,11 @@ export async function bundleSource(
     throw new Error(`No bundled output generated for ${packageName}@${version}${filename}`);
   }
 
-  let commonJsExportNames = new Set([...collectCommonJsExportNames(code), ...collectCommonJsExportNames(output.text)]);
+  let entryExportNames = collectCommonJsExportNames(code);
+  let commonJsExportNames = entryExportNames.length > 0 ? entryExportNames : collectCommonJsExportNames(output.text);
 
   return {
-    code: addCommonJsNamedExports(output.text, Array.from(commonJsExportNames).sort()),
+    code: addCommonJsNamedExports(output.text, commonJsExportNames),
   };
 }
 

--- a/packages/unpkg-files/src/lib/esm-build-service.ts
+++ b/packages/unpkg-files/src/lib/esm-build-service.ts
@@ -15,10 +15,6 @@ import { getFile, withPackageFileDirectory } from "./npm-files.ts";
 
 const defaultEsmOrigin = "https://esm.unpkg.com";
 const moduleCacheControl = "public, max-age=60, s-maxage=300";
-// esm.sh uses runtime inspection for lexer-resistant UMD packages. Keep this
-// allowlist narrow so arbitrary packages are never evaluated speculatively.
-const runtimeRevealPackages = new Set(["lodash"]);
-const runtimeRevealTimeoutMs = 10_000;
 const hardNodeBuiltins = new Set([
   "child_process",
   "cluster",
@@ -719,87 +715,7 @@ export async function analyzeCommonJsExports(
     }
   }
 
-  if (exportNames.size === 0 && runtimeRevealPackages.has(packageName)) {
-    for (let name of await revealCommonJsExports(filename, packageName, options.env, version)) {
-      exportNames.add(name);
-    }
-  }
-
   return Array.from(exportNames).sort();
-}
-
-async function revealCommonJsExports(
-  filename: string,
-  packageName: string,
-  nodeEnv: NormalizedBuildOptions["env"],
-  version: string
-): Promise<string[]> {
-  let moduleSpecifier = `npm:${packageName}@${version}${filename}`;
-  let script = [
-    "const namespace = await import(Deno.args[0]);",
-    "const value = namespace.default ?? namespace;",
-    "console.log(JSON.stringify(Object.keys(value)));",
-  ].join("\n");
-  let subprocess: Bun.Subprocess<"ignore", "pipe", "ignore">;
-
-  try {
-    // Package code receives only NODE_ENV. Filesystem, network, subprocess,
-    // FFI, and write permissions remain denied by Deno's default sandbox.
-    subprocess = Bun.spawn(
-      [
-        process.env.DENO_PATH ?? "deno",
-        "run",
-        "--allow-env=NODE_ENV",
-        "--no-config",
-        "--no-lock",
-        "--no-prompt",
-        "--quiet",
-        "--v8-flags=--max-old-space-size=128",
-        `data:application/javascript,${encodeURIComponent(script)}`,
-        moduleSpecifier,
-      ],
-      {
-        env: {
-          DENO_DIR: process.env.DENO_DIR ?? "/tmp/unpkg-deno-cache",
-          DENO_NO_PROMPT: "1",
-          DENO_NO_UPDATE_CHECK: "1",
-          NODE_ENV: nodeEnv,
-          PATH: process.env.PATH ?? "",
-        },
-        stderr: "ignore",
-        stdin: "ignore",
-        stdout: "pipe",
-      }
-    );
-  } catch {
-    return [];
-  }
-
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  try {
-    let timedOut = new Promise<never>((_, reject) => {
-      timeout = setTimeout(() => {
-        subprocess.kill();
-        reject(new Error("CommonJS runtime export reveal timed out"));
-      }, runtimeRevealTimeoutMs);
-    });
-    let [exitCode, output] = await Promise.race([
-      Promise.all([subprocess.exited, new Response(subprocess.stdout).text()]),
-      timedOut,
-    ]);
-    if (exitCode !== 0) {
-      return [];
-    }
-
-    let value = JSON.parse(output) as unknown;
-    return Array.isArray(value)
-      ? value.filter((name): name is string => typeof name === "string" && isSafeExportName(name))
-      : [];
-  } catch {
-    return [];
-  } finally {
-    if (timeout != null) clearTimeout(timeout);
-  }
 }
 
 function resolveCommonJsReexport(

--- a/packages/unpkg-files/src/lib/esm-build-service.ts
+++ b/packages/unpkg-files/src/lib/esm-build-service.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { parse as parseCommonJs } from "@esm.sh/cjs-module-lexer";
 import * as esbuild from "esbuild";
 import { parse } from "es-module-lexer/js";
 import {
@@ -14,6 +15,10 @@ import { getFile, withPackageFileDirectory } from "./npm-files.ts";
 
 const defaultEsmOrigin = "https://esm.unpkg.com";
 const moduleCacheControl = "public, max-age=60, s-maxage=300";
+// esm.sh uses runtime inspection for lexer-resistant UMD packages. Keep this
+// allowlist narrow so arbitrary packages are never evaluated speculatively.
+const runtimeRevealPackages = new Set(["lodash"]);
+const runtimeRevealTimeoutMs = 10_000;
 const hardNodeBuiltins = new Set([
   "child_process",
   "cluster",
@@ -104,6 +109,7 @@ export interface NormalizedBuildOptions {
   conditions: string[];
   dependencyOverrides: Record<string, string>;
   env: "development" | "production";
+  exportNames: string[];
   external: string[];
   ignoreAnnotations: boolean;
   jsx?: "react" | "preact" | "automatic";
@@ -297,6 +303,7 @@ export function normalizeBuildOptions(searchParams: URLSearchParams): Normalized
     conditions: parseConditions(searchParams),
     dependencyOverrides: parseDependencyOverrides(searchParams.get("deps")),
     env: searchParams.has("dev") || searchParams.get("env") === "development" ? "development" : "production",
+    exportNames: parseSelectedExports(searchParams.get("exports")),
     external: searchParams.get("external")?.split(",").filter(Boolean) ?? [],
     ignoreAnnotations: searchParams.has("ignore-annotations"),
     jsx: parseJsxMode(searchParams.get("jsx")),
@@ -360,6 +367,30 @@ export async function bundleSource(
   code: string,
   options: NormalizedBuildOptions
 ): Promise<{ code: string; map?: string }> {
+  let commonJsExportNames = await analyzeCommonJsExports(
+    packageDirectory,
+    packageJson,
+    packageName,
+    version,
+    filename,
+    code,
+    options
+  );
+  let selectEsmExports =
+    options.exportNames.length > 0 && commonJsExportNames.length === 0 && hasEsmExports(filename, code);
+  let stdin = selectEsmExports
+    ? {
+        contents: `export { ${options.exportNames.join(", ")} } from ${JSON.stringify(filename)};`,
+        loader: "js" as const,
+        resolveDir: "/",
+        sourcefile: "/__unpkg_selected_exports__.js",
+      }
+    : {
+        contents: code,
+        loader: getEsbuildLoader(filename),
+        resolveDir: path.posix.dirname(filename),
+        sourcefile: filename,
+      };
   let result = await esbuild.build({
     bundle: true,
     define: {
@@ -375,12 +406,7 @@ export async function bundleSource(
     minify: options.minify,
     plugins: [createPackageInternalBundlePlugin(packageDirectory, packageJson, packageName, version, options)],
     sourcemap: options.sourcemap ? "inline" : false,
-    stdin: {
-      contents: code,
-      loader: getEsbuildLoader(filename),
-      resolveDir: path.posix.dirname(filename),
-      sourcefile: filename,
-    },
+    stdin,
     platform: options.target === "node" ? "node" : "browser",
     target: getEsbuildTarget(options.target),
     write: false,
@@ -390,9 +416,6 @@ export async function bundleSource(
   if (output == null) {
     throw new Error(`No bundled output generated for ${packageName}@${version}${filename}`);
   }
-
-  let entryExportNames = collectCommonJsExportNames(code);
-  let commonJsExportNames = entryExportNames.length > 0 ? entryExportNames : collectCommonJsExportNames(output.text);
 
   return {
     code: addCommonJsNamedExports(output.text, commonJsExportNames),
@@ -433,6 +456,18 @@ export function parseAliases(value: string | null): Record<string, string> {
   }
 
   return aliases;
+}
+
+export function parseSelectedExports(value: string | null): string[] {
+  if (value == null || value === "") {
+    return [];
+  }
+
+  let names = value
+    .split(",")
+    .map((name) => name.trim())
+    .filter(isSelectableExportName);
+  return Array.from(new Set(names)).sort();
 }
 
 export function createBuildKey(request: BuildRequest, resolvedFilename: string): string {
@@ -546,7 +581,7 @@ export async function transformSource(
   });
 
   return {
-    code: addCommonJsNamedExports(result.code, collectCommonJsExportNames(code)),
+    code: addCommonJsNamedExports(result.code, analyzeCommonJsSource(filename, code, options.env).exports),
     map: result.map,
   };
 }
@@ -563,69 +598,263 @@ function hasDynamicRequire(code: string): boolean {
   return /\brequire\s*\(\s*[^"'`\s)]/.test(code);
 }
 
-function collectCommonJsExportNames(code: string): string[] {
-  let names = new Set<string>();
-  for (let match of code.matchAll(/\b(?:exports|module\.exports)\.([A-Za-z_$][\w$]*)\s*=/g)) {
-    names.add(match[1]);
-  }
-  for (let objectBody of collectModuleExportsObjectBodies(code)) {
-    for (let property of objectBody.matchAll(/(?:^|,)\s*([A-Za-z_$][\w$]*)\s*(?=\s*(?:[:,]|$))/g)) {
-      names.add(property[1]);
-    }
-  }
-
-  return Array.from(names).sort();
+interface CommonJsAnalysis {
+  exports: string[];
+  reexports: string[];
 }
 
-function collectModuleExportsObjectBodies(code: string): string[] {
-  let bodies: string[] = [];
-  let pattern = /\bmodule\.exports\s*=\s*{/g;
-  let match: RegExpExecArray | null;
+const reservedExportNames = new Set([
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
 
-  while ((match = pattern.exec(code)) != null) {
-    let objectStart = pattern.lastIndex - 1;
-    let objectEnd = findMatchingBrace(code, objectStart);
-    if (objectEnd !== -1) {
-      bodies.push(code.slice(objectStart + 1, objectEnd));
-      pattern.lastIndex = objectEnd + 1;
-    }
+export function analyzeCommonJsSource(
+  filename: string,
+  code: string,
+  nodeEnv: NormalizedBuildOptions["env"],
+  callMode = false
+): CommonJsAnalysis {
+  try {
+    let result = parseCommonJs(filename, code, { callMode, nodeEnv });
+    return {
+      exports: result.exports.filter(isSafeExportName),
+      reexports: result.reexports,
+    };
+  } catch {
+    return { exports: [], reexports: [] };
   }
-
-  return bodies;
 }
 
-function findMatchingBrace(code: string, openIndex: number): number {
-  let depth = 0;
-  let quote: string | null = null;
-  let escaped = false;
+export async function analyzeCommonJsExports(
+  packageDirectory: string,
+  packageJson: PackageJson,
+  packageName: string,
+  version: string,
+  filename: string,
+  code: string,
+  options: NormalizedBuildOptions
+): Promise<string[]> {
+  let exportNames = new Set<string>();
+  let pending = [{ callMode: false, code, filename }];
+  let visited = new Set<string>();
 
-  for (let index = openIndex; index < code.length; index += 1) {
-    let char = code[index];
+  while (pending.length > 0) {
+    let current = pending.pop();
+    if (current == null) continue;
 
-    if (quote != null) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
+    let visitKey = `${current.filename}\0${current.callMode}`;
+    if (visited.has(visitKey)) continue;
+    visited.add(visitKey);
+
+    if (current.filename.endsWith(".json")) {
+      for (let name of readJsonExportNames(current.code)) {
+        exportNames.add(name);
       }
       continue;
     }
 
-    if (char === '"' || char === "'" || char === "`") {
-      quote = char;
-    } else if (char === "{") {
-      depth += 1;
-    } else if (char === "}") {
-      depth -= 1;
-      if (depth === 0) {
-        return index;
+    let analysis = analyzeCommonJsSource(current.filename, current.code, options.env, current.callMode);
+    for (let name of analysis.exports) {
+      exportNames.add(name);
+    }
+
+    for (let reexport of analysis.reexports) {
+      let callMode = reexport.endsWith("()");
+      let specifier = callMode ? reexport.slice(0, -2) : reexport;
+      let resolved = resolveCommonJsReexport(current.filename, specifier, packageJson, packageName, options);
+      if (resolved == null) continue;
+
+      let file = await getFirstExistingSourceFile(packageDirectory, resolved);
+      if (file != null) {
+        pending.push({
+          callMode,
+          code: new TextDecoder().decode(file.body),
+          filename: file.path,
+        });
       }
     }
   }
 
-  return -1;
+  if (exportNames.size === 0 && runtimeRevealPackages.has(packageName)) {
+    for (let name of await revealCommonJsExports(filename, packageName, options.env, version)) {
+      exportNames.add(name);
+    }
+  }
+
+  return Array.from(exportNames).sort();
+}
+
+async function revealCommonJsExports(
+  filename: string,
+  packageName: string,
+  nodeEnv: NormalizedBuildOptions["env"],
+  version: string
+): Promise<string[]> {
+  let moduleSpecifier = `npm:${packageName}@${version}${filename}`;
+  let script = [
+    "const namespace = await import(Deno.args[0]);",
+    "const value = namespace.default ?? namespace;",
+    "console.log(JSON.stringify(Object.keys(value)));",
+  ].join("\n");
+  let subprocess: Bun.Subprocess<"ignore", "pipe", "ignore">;
+
+  try {
+    // Package code receives only NODE_ENV. Filesystem, network, subprocess,
+    // FFI, and write permissions remain denied by Deno's default sandbox.
+    subprocess = Bun.spawn(
+      [
+        process.env.DENO_PATH ?? "deno",
+        "run",
+        "--allow-env=NODE_ENV",
+        "--no-config",
+        "--no-lock",
+        "--no-prompt",
+        "--quiet",
+        "--v8-flags=--max-old-space-size=128",
+        `data:application/javascript,${encodeURIComponent(script)}`,
+        moduleSpecifier,
+      ],
+      {
+        env: {
+          DENO_DIR: process.env.DENO_DIR ?? "/tmp/unpkg-deno-cache",
+          DENO_NO_PROMPT: "1",
+          DENO_NO_UPDATE_CHECK: "1",
+          NODE_ENV: nodeEnv,
+          PATH: process.env.PATH ?? "",
+        },
+        stderr: "ignore",
+        stdin: "ignore",
+        stdout: "pipe",
+      }
+    );
+  } catch {
+    return [];
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    let timedOut = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        subprocess.kill();
+        reject(new Error("CommonJS runtime export reveal timed out"));
+      }, runtimeRevealTimeoutMs);
+    });
+    let [exitCode, output] = await Promise.race([
+      Promise.all([subprocess.exited, new Response(subprocess.stdout).text()]),
+      timedOut,
+    ]);
+    if (exitCode !== 0) {
+      return [];
+    }
+
+    let value = JSON.parse(output) as unknown;
+    return Array.isArray(value)
+      ? value.filter((name): name is string => typeof name === "string" && isSafeExportName(name))
+      : [];
+  } catch {
+    return [];
+  } finally {
+    if (timeout != null) clearTimeout(timeout);
+  }
+}
+
+function resolveCommonJsReexport(
+  containingFilename: string,
+  specifier: string,
+  packageJson: PackageJson,
+  packageName: string,
+  options: NormalizedBuildOptions
+): string | null {
+  if (specifier.startsWith(".")) {
+    let resolved = path.posix.normalize(path.posix.join(path.posix.dirname(containingFilename), specifier));
+    return resolved.startsWith("/") ? resolved : `/${resolved}`;
+  }
+
+  let parsed = parseBareSpecifier(specifier);
+  if (parsed?.packageName !== packageName) {
+    return null;
+  }
+
+  let selfReferencePath = parsed.path === "" ? "/" : parsed.path;
+  return resolveBuildFilename(packageJson, selfReferencePath, options) ?? selfReferencePath;
+}
+
+function readJsonExportNames(code: string): string[] {
+  try {
+    let value = JSON.parse(code) as unknown;
+    if (typeof value !== "object" || value == null || Array.isArray(value)) {
+      return [];
+    }
+
+    return Object.keys(value).filter(isSafeExportName);
+  } catch {
+    return [];
+  }
+}
+
+function isSafeExportName(name: string): boolean {
+  return /^[A-Za-z_$][\w$]*$/.test(name) && !reservedExportNames.has(name);
+}
+
+function isSelectableExportName(name: string): boolean {
+  return name === "default" || isSafeExportName(name);
+}
+
+function hasEsmExports(filename: string, code: string): boolean {
+  if (filename.endsWith(".mjs") || filename.endsWith(".mts")) {
+    return true;
+  }
+
+  try {
+    let [, exports] = parse(code);
+    return exports.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 function addCommonJsNamedExports(code: string, exportNames: string[]): string {
@@ -642,8 +871,14 @@ function addCommonJsNamedExports(code: string, exportNames: string[]): string {
     return code;
   }
 
-  let namedExports = exportNames.map((name) => `export const ${name} = __unpkg_cjs_default.${name};`).join("\n");
-  return code.slice(0, match.index) + `var __unpkg_cjs_default = ${match[1]};\nexport { __unpkg_cjs_default as default };\n${namedExports}\n`;
+  let namedExportDeclarations = exportNames
+    .map((name, index) => `const __unpkg_cjs_export_${index} = __unpkg_cjs_default[${JSON.stringify(name)}];`)
+    .join("\n");
+  let namedExportSpecifiers = exportNames.map((name, index) => `__unpkg_cjs_export_${index} as ${name}`).join(", ");
+  return (
+    code.slice(0, match.index) +
+    `var __unpkg_cjs_default = ${match[1]};\n${namedExportDeclarations}\nexport { __unpkg_cjs_default as default, ${namedExportSpecifiers} };\n`
+  );
 }
 
 function createPackageInternalBundlePlugin(

--- a/packages/unpkg-worker/src/lib/esm-url.test.ts
+++ b/packages/unpkg-worker/src/lib/esm-url.test.ts
@@ -91,6 +91,14 @@ describe("normalizeEsmRequestUrl", () => {
     expect("url" in cssPackage && cssPackage.url.search).toBe("");
     expect("url" in cssModule && cssModule.url.search).toBe("?module=");
   });
+
+  it("does not add a default target to declaration assets", () => {
+    let typesPackage = normalizeEsmRequestUrl("https://esm.unpkg.com/@types/react@18.2.0?dev");
+    let declaration = normalizeEsmRequestUrl("https://esm.unpkg.com/preact@10.26.4/src/index.d.ts?dev");
+
+    expect("url" in typesPackage && typesPackage.url.search).toBe("?dev=");
+    expect("url" in declaration && declaration.url.search).toBe("?dev=");
+  });
 });
 
 describe("getEsmPackageSubpath", () => {

--- a/packages/unpkg-worker/src/lib/esm-url.ts
+++ b/packages/unpkg-worker/src/lib/esm-url.ts
@@ -83,7 +83,11 @@ export function normalizeEsmRequestUrl(requestUrl: string | URL): NormalizedEsmR
     return validationError;
   }
 
-  if (!url.searchParams.has("target") && !url.searchParams.has("raw") && !isCssRequest(packagePath, url.searchParams)) {
+  if (
+    !url.searchParams.has("target") &&
+    !url.searchParams.has("raw") &&
+    !isUntargetedAssetRequest(packagePath, url.searchParams)
+  ) {
     url.searchParams.set("target", "es2022");
   }
 
@@ -99,12 +103,18 @@ export function normalizeEsmRequestUrl(requestUrl: string | URL): NormalizedEsmR
   };
 }
 
-function isCssRequest(packagePath: EsmPackagePath, searchParams: URLSearchParams): boolean {
+function isUntargetedAssetRequest(packagePath: EsmPackagePath, searchParams: URLSearchParams): boolean {
   return (
     searchParams.has("css") ||
+    packagePath.package.toLowerCase().startsWith("@types/") ||
     packagePath.package.endsWith(".css") ||
-    packagePath.filename?.endsWith(".css") === true
+    packagePath.filename?.endsWith(".css") === true ||
+    isTypeDeclarationPath(packagePath.filename)
   );
+}
+
+function isTypeDeclarationPath(filename: string | undefined): boolean {
+  return filename?.endsWith(".d.ts") || filename?.endsWith(".d.mts") || filename?.endsWith(".d.cts") || false;
 }
 
 export function parseEsmPackagePathname(pathname: string): EsmPackagePath | null {

--- a/packages/unpkg-worker/src/lib/pkg-exports.test.ts
+++ b/packages/unpkg-worker/src/lib/pkg-exports.test.ts
@@ -187,6 +187,40 @@ describe("resolvePackageExport", () => {
     });
   });
 
+  describe("when package.exports contains wildcard subpaths", () => {
+    let packageJson = {
+      exports: {
+        "./features/special/*": {
+          import: "./esm/special/*.mjs",
+          default: "./special/*.js",
+        },
+        "./*": {
+          import: "./esm/*.mjs",
+          default: "./*.js",
+        },
+        "./exact": "./exact.js",
+      },
+    } as unknown as PackageJson;
+
+    it("substitutes wildcard matches through conditions", () => {
+      expect(resolvePackageExport(packageJson, "/vanilla", { conditions: ["import"] })).toBe("/esm/vanilla.mjs");
+    });
+
+    it("prefers exact subpaths over wildcard matches", () => {
+      expect(resolvePackageExport(packageJson, "/exact", { conditions: ["import"] })).toBe("/exact.js");
+    });
+
+    it("prefers the most specific wildcard", () => {
+      expect(resolvePackageExport(packageJson, "/features/special/client", { conditions: ["import"] })).toBe(
+        "/esm/special/client.mjs"
+      );
+    });
+
+    it("uses the matching fallback condition", () => {
+      expect(resolvePackageExport(packageJson, "/vanilla", { conditions: ["default"] })).toBe("/vanilla.js");
+    });
+  });
+
   describe("when package.exports is a nested object with subpaths and export conditions", () => {
     let packageJson = {
       exports: {

--- a/packages/unpkg-worker/src/lib/pkg-exports.ts
+++ b/packages/unpkg-worker/src/lib/pkg-exports.ts
@@ -106,35 +106,55 @@ export function resolveExportConditions(
   entry: string,
   supportedConditions: string[]
 ): string | null {
-  return _resolveExportConditions(exports, entry, supportedConditions, entry === ".");
+  return _resolveExportConditions(exports, entry, supportedConditions, entry === ".", null);
 }
 
 function _resolveExportConditions(
   exports: ExportConditions,
   entry: string,
   supportedConditions: string[],
-  entryWasFound: boolean
+  entryWasFound: boolean,
+  wildcardMatch: string | null
 ): string | null {
+  for (let key in exports) {
+    if (!isSubpath(key) || entry !== normalizeEntryPath(key)) continue;
+
+    let value = exports[key];
+    if (typeof value === "string") {
+      return applyWildcardMatch(value, wildcardMatch);
+    }
+
+    return _resolveExportConditions(value, entry, supportedConditions, true, wildcardMatch);
+  }
+
+  let wildcardEntries = Object.entries(exports)
+    .filter(([key]) => isSubpath(key) && key.includes("*"))
+    .map(([key, value]) => {
+      let match = matchWildcardExport(normalizeEntryPath(key), entry);
+      return match == null ? null : { key, match, value };
+    })
+    .filter((candidate): candidate is NonNullable<typeof candidate> => candidate != null)
+    .sort((left, right) => wildcardSpecificity(right.key) - wildcardSpecificity(left.key));
+
+  for (let { match, value } of wildcardEntries) {
+    if (typeof value === "string") {
+      return applyWildcardMatch(value, match);
+    }
+
+    let resolved = _resolveExportConditions(value, entry, supportedConditions, true, match);
+    if (resolved != null) {
+      return resolved;
+    }
+  }
+
   for (let key in exports) {
     let value = exports[key];
 
-    if (isSubpath(key)) {
-      if (entry === normalizeEntryPath(key)) {
-        if (typeof value === "string") {
-          // "exports": { ".": "./dist/index.js" }
-          return value;
-        } else {
-          // "exports": { ".": { ... } }
-          return _resolveExportConditions(value, entry, supportedConditions, true);
-        }
-      }
-    } else if (supportedConditions.includes(key)) {
+    if (!isSubpath(key) && supportedConditions.includes(key)) {
       if (typeof value === "string") {
-        // "exports": { "import": "./dist/index.mjs" }
-        if (entryWasFound) return value;
+        if (entryWasFound) return applyWildcardMatch(value, wildcardMatch);
       } else {
-        // "exports": { "import": { ... } }
-        let resolved = _resolveExportConditions(value, entry, supportedConditions, entryWasFound);
+        let resolved = _resolveExportConditions(value, entry, supportedConditions, entryWasFound, wildcardMatch);
         if (resolved != null) {
           return resolved;
         }
@@ -143,6 +163,25 @@ function _resolveExportConditions(
   }
 
   return null;
+}
+
+function matchWildcardExport(pattern: string, entry: string): string | null {
+  let wildcardIndex = pattern.indexOf("*");
+  let prefix = pattern.slice(0, wildcardIndex);
+  let suffix = pattern.slice(wildcardIndex + 1);
+  if (!entry.startsWith(prefix) || !entry.endsWith(suffix)) {
+    return null;
+  }
+
+  return entry.slice(prefix.length, entry.length - suffix.length);
+}
+
+function wildcardSpecificity(pattern: string): number {
+  return pattern.replace("*", "").length;
+}
+
+function applyWildcardMatch(value: string, wildcardMatch: string | null): string {
+  return wildcardMatch == null ? value : value.replaceAll("*", wildcardMatch);
 }
 
 function isSubpath(path: string): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
 
   packages/unpkg-files:
     dependencies:
+      '@esm.sh/cjs-module-lexer':
+        specifier: 1.1.0
+        version: 1.1.0
       chalk:
         specifier: ^5.4.1
         version: 5.4.1
@@ -420,6 +423,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@esm.sh/cjs-module-lexer@1.1.0':
+    resolution: {integrity: sha512-IjpcpUe1mYxPBnGreYMxDSbdVmD2zFXxHeJ2EbJsbTkC+RDAjPQDpkvOSYzB0qYo4npBtwrgLiGYcUVfyH6b8g==}
 
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
@@ -1146,6 +1152,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.24.2':
     optional: true
+
+  '@esm.sh/cjs-module-lexer@1.1.0': {}
 
   '@fastify/busboy@2.1.1': {}
 

--- a/scripts/esm-browser-parity.test.ts
+++ b/scripts/esm-browser-parity.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "bun:test";
+
+import { compareExportKeys } from "./esm-browser-parity.ts";
+
+describe("compareExportKeys", () => {
+  it("ignores export ordering", () => {
+    expect(compareExportKeys(["render", "default", "hydrate"], ["default", "hydrate", "render"])).toBeNull();
+  });
+
+  it("reports missing and extra exports", () => {
+    expect(compareExportKeys(["createRoot", "hydrateRoot"], ["createRoot", "render"])).toBe(
+      'export surface mismatch: missing=["hydrateRoot"], extra=["render"]'
+    );
+  });
+});

--- a/scripts/esm-browser-parity.test.ts
+++ b/scripts/esm-browser-parity.test.ts
@@ -12,4 +12,8 @@ describe("compareExportKeys", () => {
       'export surface mismatch: missing=["hydrateRoot"], extra=["render"]'
     );
   });
+
+  it("allows explicitly documented export-surface divergences", () => {
+    expect(compareExportKeys(["default", "map"], ["default"], "expected-only")).toBeNull();
+  });
 });

--- a/scripts/esm-browser-parity.ts
+++ b/scripts/esm-browser-parity.ts
@@ -1,4 +1,12 @@
-export function compareExportKeys(baseline: readonly string[], candidate: readonly string[]): string | null {
+export function compareExportKeys(
+  baseline: readonly string[],
+  candidate: readonly string[],
+  mode: "match" | "expected-only" = "match"
+): string | null {
+  if (mode === "expected-only") {
+    return null;
+  }
+
   let baselineSet = new Set(baseline);
   let candidateSet = new Set(candidate);
   let missing = [...baselineSet].filter((name) => !candidateSet.has(name)).sort();

--- a/scripts/esm-browser-parity.ts
+++ b/scripts/esm-browser-parity.ts
@@ -1,0 +1,12 @@
+export function compareExportKeys(baseline: readonly string[], candidate: readonly string[]): string | null {
+  let baselineSet = new Set(baseline);
+  let candidateSet = new Set(candidate);
+  let missing = [...baselineSet].filter((name) => !candidateSet.has(name)).sort();
+  let extra = [...candidateSet].filter((name) => !baselineSet.has(name)).sort();
+
+  if (missing.length === 0 && extra.length === 0) {
+    return null;
+  }
+
+  return `export surface mismatch: missing=${JSON.stringify(missing)}, extra=${JSON.stringify(extra)}`;
+}

--- a/scripts/esm-browser-smoke.ts
+++ b/scripts/esm-browser-smoke.ts
@@ -9,6 +9,7 @@ interface CompatCase {
   category?: string;
   description: string;
   expect: "module" | "javascript" | "json" | "css" | "typescript" | "diagnostic";
+  exportParity?: "expected-only";
   features?: string[];
   package?: string;
   path: string;
@@ -151,7 +152,9 @@ function addBaselineParity(
 
   let parityError =
     result.error ??
-    (baseline.error == null ? compareExportKeys(baseline.exportKeys, result.exportKeys) : `Baseline failed: ${baseline.error}`);
+    (baseline.error == null
+      ? compareExportKeys(baseline.exportKeys, result.exportKeys, result.case.exportParity ?? "match")
+      : `Baseline failed: ${baseline.error}`);
   return {
     ...result,
     baselineExportKeys: baseline.exportKeys,
@@ -602,7 +605,11 @@ function isCompatCorpus(value: unknown): value is CompatCorpus {
 function isCompatCase(value: unknown): value is CompatCase {
   if (typeof value !== "object" || value == null) return false;
   let compatCase = value as Record<string, unknown>;
-  return typeof compatCase.description === "string" && typeof compatCase.path === "string";
+  return (
+    typeof compatCase.description === "string" &&
+    typeof compatCase.path === "string" &&
+    (compatCase.exportParity == null || compatCase.exportParity === "expected-only")
+  );
 }
 
 function parseArgs(args: string[]): {

--- a/scripts/esm-browser-smoke.ts
+++ b/scripts/esm-browser-smoke.ts
@@ -3,10 +3,12 @@
 import { readFile } from "node:fs/promises";
 import { chromium } from "playwright";
 
+import { compareExportKeys } from "./esm-browser-parity.ts";
+
 interface CompatCase {
   category?: string;
   description: string;
-  expect: "module" | "json" | "css" | "diagnostic";
+  expect: "module" | "javascript" | "json" | "css" | "typescript" | "diagnostic";
   features?: string[];
   package?: string;
   path: string;
@@ -24,6 +26,7 @@ interface CompatCorpus {
 }
 
 interface BrowserSmokeResult {
+  baselineExportKeys?: string[];
   case: CompatCase;
   durationMs: number;
   error: string | null;
@@ -34,6 +37,7 @@ interface BrowserSmokeResult {
 }
 
 interface BrowserSmokeReport {
+  baselineOrigin?: string;
   browser: "chromium";
   corpus: string;
   createdAt: string;
@@ -46,6 +50,7 @@ interface BrowserSmokeReport {
 
 let options = parseArgs(process.argv.slice(2));
 let origin = stripTrailingSlash(options.origin ?? process.env.ESM_BROWSER_ORIGIN ?? "https://esm.sh");
+let baselineOrigin = options.baselineOrigin == null ? null : stripTrailingSlash(options.baselineOrigin);
 let runOrigin = stripTrailingSlash(options.runOrigin ?? process.env.UNPKG_RUN_ORIGIN ?? origin);
 let corpus = await loadCorpus(options.corpusPath);
 let smokeCases = corpus.cases.filter((compatCase) => {
@@ -79,6 +84,7 @@ if (options.dryRun) {
   }));
   let results = [...importResults, ...runtimeResults];
   printReport({
+    baselineOrigin: baselineOrigin ?? undefined,
     browser: "chromium",
     corpus: corpus.name ?? options.corpusPath,
     createdAt: new Date().toISOString(),
@@ -103,8 +109,21 @@ try {
     results.push(await runRuntimeCase(page, runtimeCase, origin));
   }
 
+  if (baselineOrigin != null) {
+    let baselineResults: BrowserSmokeResult[] = [];
+    for (let compatCase of smokeCases) {
+      baselineResults.push(await runCase(page, compatCase, baselineOrigin));
+    }
+    for (let runtimeCase of runtimeCases) {
+      baselineResults.push(await runRuntimeCase(page, runtimeCase, baselineOrigin));
+    }
+
+    results = results.map((result, index) => addBaselineParity(result, baselineResults[index]));
+  }
+
   let failed = results.filter((result) => result.error != null).length;
   printReport({
+    baselineOrigin: baselineOrigin ?? undefined,
     browser: "chromium",
     corpus: corpus.name ?? options.corpusPath,
     createdAt: new Date().toISOString(),
@@ -120,6 +139,24 @@ try {
   }
 } finally {
   await browser.close();
+}
+
+function addBaselineParity(
+  result: BrowserSmokeResult,
+  baseline: BrowserSmokeResult | undefined
+): BrowserSmokeResult {
+  if (baseline == null) {
+    return { ...result, error: result.error ?? "Missing baseline browser result" };
+  }
+
+  let parityError =
+    result.error ??
+    (baseline.error == null ? compareExportKeys(baseline.exportKeys, result.exportKeys) : `Baseline failed: ${baseline.error}`);
+  return {
+    ...result,
+    baselineExportKeys: baseline.exportKeys,
+    error: parityError,
+  };
 }
 
 async function runCase(page: import("playwright").Page, compatCase: CompatCase, origin: string): Promise<BrowserSmokeResult> {
@@ -545,7 +582,8 @@ function printReport(report: BrowserSmokeReport, jsonOutput: boolean): void {
     return;
   }
 
-  console.log(`${report.corpus}: ${report.passed}/${report.total} browser smoke cases passed against ${report.origin}`);
+  let comparison = report.baselineOrigin == null ? "" : ` versus ${report.baselineOrigin}`;
+  console.log(`${report.corpus}: ${report.passed}/${report.total} browser smoke cases passed against ${report.origin}${comparison}`);
   for (let result of report.results) {
     let marker = result.error == null ? "PASS" : "FAIL";
     console.log(`${marker} ${result.case.description}: ${result.requestCount} requests, ${result.transferredBytes} bytes`);
@@ -568,6 +606,7 @@ function isCompatCase(value: unknown): value is CompatCase {
 }
 
 function parseArgs(args: string[]): {
+  baselineOrigin: string | null;
   corpusPath: string;
   dryRun: boolean;
   jsonOutput: boolean;
@@ -576,6 +615,7 @@ function parseArgs(args: string[]): {
   packageName: string | null;
   runOrigin: string | null;
 } {
+  let baselineOrigin: string | null = null;
   let corpusPath = "scripts/esm-compat-corpus.seed.json";
   let dryRun = false;
   let jsonOutput = false;
@@ -591,6 +631,11 @@ function parseArgs(args: string[]): {
       index += 1;
     } else if (arg.startsWith("--corpus=")) {
       corpusPath = arg.slice("--corpus=".length);
+    } else if (arg === "--baseline-origin") {
+      baselineOrigin = args[index + 1] ?? null;
+      index += 1;
+    } else if (arg.startsWith("--baseline-origin=")) {
+      baselineOrigin = arg.slice("--baseline-origin=".length);
     } else if (arg === "--dry-run") {
       dryRun = true;
     } else if (arg === "--json") {
@@ -621,6 +666,7 @@ function parseArgs(args: string[]): {
   }
 
   return {
+    baselineOrigin,
     corpusPath,
     dryRun,
     jsonOutput,

--- a/scripts/esm-compat-corpus.ecosystem.json
+++ b/scripts/esm-compat-corpus.ecosystem.json
@@ -1453,7 +1453,8 @@
         "package-root"
       ],
       "package": "lodash",
-      "path": "/lodash@4.18.1"
+      "path": "/lodash@4.18.1",
+      "exportParity": "expected-only"
     },
     {
       "category": "cjs",

--- a/scripts/esm-compat-corpus.ecosystem.json
+++ b/scripts/esm-compat-corpus.ecosystem.json
@@ -8,7 +8,7 @@
     {
       "category": "cjs",
       "description": "Package root for @babel/runtime@7.29.2",
-      "expect": "module",
+      "expect": "diagnostic",
       "features": [
         "package-root"
       ],
@@ -18,7 +18,7 @@
     {
       "category": "cjs",
       "description": "Metadata for @babel/runtime@7.29.2",
-      "expect": "json",
+      "expect": "diagnostic",
       "features": [
         "meta"
       ],
@@ -298,7 +298,7 @@
     {
       "category": "types",
       "description": "Package root for @types/react@19.2.14",
-      "expect": "module",
+      "expect": "typescript",
       "features": [
         "package-root"
       ],
@@ -307,8 +307,8 @@
     },
     {
       "category": "types",
-      "description": "Metadata for @types/react@19.2.14",
-      "expect": "json",
+      "description": "Metadata query redirects for types-only @types/react@19.2.14",
+      "expect": "typescript",
       "features": [
         "meta"
       ],
@@ -3789,7 +3789,8 @@
         "subpath"
       ],
       "package": "react-toastify",
-      "path": "/react-toastify@11.0.5/dist/ReactToastify.css"
+      "path": "/react-toastify@11.0.5/dist/ReactToastify.css",
+      "contentParity": "expected-only"
     },
     {
       "category": "css",

--- a/scripts/esm-compat-corpus.medium.json
+++ b/scripts/esm-compat-corpus.medium.json
@@ -536,7 +536,8 @@
       "expect": "css",
       "features": ["css", "subpath"],
       "package": "react-toastify",
-      "path": "/react-toastify@11.0.5/dist/ReactToastify.css"
+      "path": "/react-toastify@11.0.5/dist/ReactToastify.css",
+      "contentParity": "expected-only"
     },
     {
       "category": "css",

--- a/scripts/esm-compat-corpus.medium.json
+++ b/scripts/esm-compat-corpus.medium.json
@@ -192,7 +192,8 @@
       "expect": "module",
       "features": ["commonjs"],
       "package": "lodash",
-      "path": "/lodash@4.17.21"
+      "path": "/lodash@4.17.21",
+      "exportParity": "expected-only"
     },
     {
       "category": "library",

--- a/scripts/esm-compat-corpus.seed.json
+++ b/scripts/esm-compat-corpus.seed.json
@@ -206,6 +206,15 @@
     },
     {
       "category": "build-options",
+      "description": "Selected ESM exports",
+      "expect": "module",
+      "features": ["exports-selection", "tree-shaking"],
+      "package": "preact",
+      "path": "/preact@10.26.4?exports=h,render",
+      "preserveRedirectQuery": ["exports"]
+    },
+    {
+      "category": "build-options",
       "description": "Keep names option",
       "expect": "module",
       "features": ["keep-names"],

--- a/scripts/esm-compat-corpus.seed.json
+++ b/scripts/esm-compat-corpus.seed.json
@@ -32,7 +32,8 @@
       "expect": "module",
       "features": ["external"],
       "package": "react-dom",
-      "path": "/react-dom@18.3.1/client?external=react"
+      "path": "/react-dom@18.3.1/client?external=react",
+      "preserveRedirectQuery": ["external"]
     },
     {
       "category": "dependency-control",
@@ -40,7 +41,8 @@
       "expect": "module",
       "features": ["deps"],
       "package": "react-dom",
-      "path": "/react-dom@18.3.1/client?deps=react@18.2.0"
+      "path": "/react-dom@18.3.1/client?deps=react@18.2.0",
+      "preserveRedirectQuery": ["deps"]
     },
     {
       "category": "dependency-control",
@@ -48,7 +50,8 @@
       "expect": "module",
       "features": ["alias", "deps"],
       "package": "react-dom",
-      "path": "/react-dom@18.3.1/client?alias=react:preact/compat&deps=preact@10.25.4"
+      "path": "/react-dom@18.3.1/client?alias=react:preact/compat&deps=preact@10.25.4",
+      "preserveRedirectQuery": ["alias", "deps"]
     },
     {
       "category": "bundling",
@@ -56,7 +59,8 @@
       "expect": "module",
       "features": ["no-bundle"],
       "package": "preact",
-      "path": "/preact@10.26.4/hooks?no-bundle"
+      "path": "/preact@10.26.4/hooks?no-bundle",
+      "preserveRedirectQuery": ["no-bundle"]
     },
     {
       "category": "bundling",
@@ -64,7 +68,8 @@
       "expect": "module",
       "features": ["bundle-false"],
       "package": "preact",
-      "path": "/preact@10.26.4/hooks?bundle=false"
+      "path": "/preact@10.26.4/hooks?bundle=false",
+      "preserveRedirectQuery": ["bundle"]
     },
     {
       "category": "bundling",
@@ -72,7 +77,8 @@
       "expect": "module",
       "features": ["bundle"],
       "package": "preact",
-      "path": "/preact@10.26.4/hooks?bundle"
+      "path": "/preact@10.26.4/hooks?bundle",
+      "preserveRedirectQuery": ["bundle"]
     },
     {
       "category": "bundling",
@@ -80,7 +86,8 @@
       "expect": "module",
       "features": ["standalone"],
       "package": "preact",
-      "path": "/preact@10.26.4/hooks?standalone"
+      "path": "/preact@10.26.4/hooks?standalone",
+      "preserveRedirectQuery": ["standalone"]
     },
     {
       "category": "raw",
@@ -88,7 +95,62 @@
       "expect": "json",
       "features": ["raw"],
       "package": "react",
-      "path": "/react@18.3.1/package.json?raw"
+      "path": "/react@18.3.1/package.json?raw",
+      "preserveRedirectQuery": ["raw"]
+    },
+    {
+      "category": "redirect-query",
+      "description": "Raw CommonJS package roots redirect to their entry asset",
+      "expect": "javascript",
+      "features": ["redirect", "query-forwarding", "raw", "package-root", "commonjs"],
+      "package": "react",
+      "path": "/react@18?raw",
+      "redirectParity": "final-path-and-query"
+    },
+    {
+      "category": "redirect-query",
+      "description": "Raw ESM package roots redirect through import exports",
+      "expect": "javascript",
+      "features": ["redirect", "query-forwarding", "raw", "package-root", "exports"],
+      "package": "preact",
+      "path": "/preact@10.26.4?raw",
+      "redirectParity": "final-path-and-query"
+    },
+    {
+      "category": "redirect-query",
+      "description": "Raw exported subpaths redirect to their source asset",
+      "expect": "javascript",
+      "features": ["redirect", "query-forwarding", "raw", "subpath", "exports"],
+      "package": "react",
+      "path": "/react@18.3.1/jsx-runtime?raw",
+      "redirectParity": "final-path-and-query"
+    },
+    {
+      "category": "redirect-query",
+      "description": "Raw scoped package roots redirect through conditional exports",
+      "expect": "javascript",
+      "features": ["redirect", "query-forwarding", "raw", "scoped-package", "exports"],
+      "package": "@tanstack/query-core",
+      "path": "/@tanstack/query-core@5.64.1?raw",
+      "redirectParity": "final-path-and-query"
+    },
+    {
+      "category": "redirect-query",
+      "description": "Raw extensionless scoped subpaths redirect to JavaScript assets",
+      "expect": "javascript",
+      "features": ["redirect", "query-forwarding", "raw", "scoped-package", "subpath", "extensionless"],
+      "package": "@babel/runtime",
+      "path": "/@babel/runtime@7.26.0/helpers/extends?raw",
+      "redirectParity": "final-path-and-query"
+    },
+    {
+      "category": "redirect-query",
+      "description": "Raw package roots prefer module entries over stylesheet metadata",
+      "expect": "javascript",
+      "features": ["redirect", "query-forwarding", "raw", "package-root", "module-field", "css"],
+      "package": "bootstrap",
+      "path": "/bootstrap@5.3.8?raw",
+      "redirectParity": "final-path-and-query"
     },
     {
       "category": "diagnostic",
@@ -104,7 +166,17 @@
       "expect": "module",
       "features": ["dev"],
       "package": "react",
-      "path": "/react@18.3.1?dev"
+      "path": "/react@18.3.1?dev",
+      "preserveRedirectQuery": ["dev"]
+    },
+    {
+      "category": "redirect-query",
+      "description": "Semver redirects preserve build query parameters",
+      "expect": "module",
+      "features": ["redirect", "query-forwarding", "dev", "external", "target"],
+      "package": "react",
+      "path": "/react@18?dev&external=react&target=es2020",
+      "preserveRedirectQuery": ["dev", "external", "target"]
     },
     {
       "category": "build-options",
@@ -112,7 +184,8 @@
       "expect": "module",
       "features": ["env"],
       "package": "react",
-      "path": "/react@18.3.1?env=development"
+      "path": "/react@18.3.1?env=development",
+      "preserveRedirectQuery": ["env"]
     },
     {
       "category": "build-options",
@@ -128,7 +201,8 @@
       "expect": "module",
       "features": ["conditions"],
       "package": "preact",
-      "path": "/preact@10.26.4?conditions=browser,development"
+      "path": "/preact@10.26.4?conditions=browser,development",
+      "preserveRedirectQuery": ["conditions"]
     },
     {
       "category": "build-options",
@@ -136,7 +210,8 @@
       "expect": "module",
       "features": ["keep-names"],
       "package": "preact",
-      "path": "/preact@10.26.4?keep-names"
+      "path": "/preact@10.26.4?keep-names",
+      "preserveRedirectQuery": ["keep-names"]
     },
     {
       "category": "build-options",
@@ -144,7 +219,8 @@
       "expect": "module",
       "features": ["ignore-annotations"],
       "package": "preact",
-      "path": "/preact@10.26.4?ignore-annotations"
+      "path": "/preact@10.26.4?ignore-annotations",
+      "preserveRedirectQuery": ["ignore-annotations"]
     },
     {
       "category": "build-options",
@@ -152,7 +228,8 @@
       "expect": "module",
       "features": ["min"],
       "package": "preact",
-      "path": "/preact@10.26.4?min"
+      "path": "/preact@10.26.4?min",
+      "preserveRedirectQuery": ["min"]
     },
     {
       "category": "build-options",
@@ -160,7 +237,8 @@
       "expect": "module",
       "features": ["sourcemap"],
       "package": "preact",
-      "path": "/preact@10.26.4?sourcemap"
+      "path": "/preact@10.26.4?sourcemap",
+      "preserveRedirectQuery": ["sourcemap"]
     },
     {
       "category": "types",
@@ -168,7 +246,26 @@
       "expect": "module",
       "features": ["no-dts"],
       "package": "preact",
-      "path": "/preact@10.26.4?no-dts"
+      "path": "/preact@10.26.4?no-dts",
+      "preserveRedirectQuery": ["no-dts"]
+    },
+    {
+      "category": "redirect-query",
+      "description": "Types-only package redirects strip build queries from declaration assets",
+      "expect": "typescript",
+      "features": ["redirect", "query-forwarding", "types", "target"],
+      "package": "@types/react",
+      "path": "/@types/react@18.2.0?target=es2020",
+      "redirectParity": "final-path-and-query"
+    },
+    {
+      "category": "redirect-query",
+      "description": "Types-only roots ignore typesVersions wildcard directories",
+      "expect": "typescript",
+      "features": ["redirect", "query-forwarding", "types", "types-versions", "raw"],
+      "package": "@types/node",
+      "path": "/@types/node@22.10.2?raw",
+      "redirectParity": "final-path-and-query"
     },
     {
       "category": "import-map",
@@ -184,7 +281,8 @@
       "expect": "json",
       "features": ["meta"],
       "package": "preact",
-      "path": "/preact@10.26.4?meta"
+      "path": "/preact@10.26.4?meta",
+      "preserveRedirectQuery": ["meta"]
     },
     {
       "category": "worker",
@@ -192,7 +290,8 @@
       "expect": "module",
       "features": ["worker"],
       "package": "preact",
-      "path": "/preact@10.26.4?worker"
+      "path": "/preact@10.26.4?worker",
+      "preserveRedirectQuery": ["worker"]
     },
     {
       "category": "runtime-target",
@@ -219,6 +318,24 @@
       "path": "/normalize.css@8.0.1"
     },
     {
+      "category": "redirect-query",
+      "description": "CSS entry redirects strip irrelevant build queries",
+      "expect": "css",
+      "features": ["redirect", "query-forwarding", "css", "target"],
+      "package": "normalize.css",
+      "path": "/normalize.css@8.0.1?target=es2020",
+      "redirectParity": "final-path-and-query"
+    },
+    {
+      "category": "redirect-query",
+      "description": "Raw CSS package roots redirect to the stylesheet asset",
+      "expect": "css",
+      "features": ["redirect", "query-forwarding", "css", "raw"],
+      "package": "normalize.css",
+      "path": "/normalize.css@8.0.1?raw",
+      "redirectParity": "final-path-and-query"
+    },
+    {
       "category": "css",
       "description": "Direct CSS file",
       "expect": "css",
@@ -232,7 +349,8 @@
       "expect": "module",
       "features": ["css", "css-module"],
       "package": "react-toastify",
-      "path": "/react-toastify@11.0.5/dist/ReactToastify.css?module"
+      "path": "/react-toastify@11.0.5/dist/ReactToastify.css?module",
+      "preserveRedirectQuery": ["module"]
     },
     {
       "category": "css",

--- a/scripts/esm-compat-redirects.test.ts
+++ b/scripts/esm-compat-redirects.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  compareFinalPathAndQuery,
+  comparePreservedQueryParams,
+  comparePreservedQueryParamsAcrossRedirects,
+} from "./esm-compat-redirects.ts";
+
+describe("compareFinalPathAndQuery", () => {
+  it("ignores origins and query parameter ordering", () => {
+    expect(
+      compareFinalPathAndQuery(
+        "https://esm.sh/react@18.3.1?dev=&target=es2020",
+        "https://esm.unpkg.com/react@18.3.1?target=es2020&dev="
+      )
+    ).toBeNull();
+  });
+
+  it("reports changed final asset queries", () => {
+    expect(
+      compareFinalPathAndQuery(
+        "https://esm.sh/normalize.css@8.0.1/normalize.css",
+        "https://esm.unpkg.com/normalize.css@8.0.1/normalize.css?target=es2020"
+      )
+    ).toContain("final redirect target mismatch");
+  });
+});
+
+describe("comparePreservedQueryParams", () => {
+  it("accepts preserved flags, values, and duplicate parameters", () => {
+    expect(
+      comparePreservedQueryParams(
+        "https://esm.unpkg.com/react@18?conditions=browser&conditions=development&dev",
+        "https://esm.unpkg.com/react@18.3.1?dev=&conditions=development&conditions=browser&target=es2022",
+        ["conditions", "dev"]
+      )
+    ).toBeNull();
+  });
+
+  it("reports dropped parameters", () => {
+    expect(
+      comparePreservedQueryParams(
+        "https://esm.unpkg.com/react@18?dev&target=es2020",
+        "https://esm.unpkg.com/react@18.3.1?target=es2020",
+        ["dev", "target"]
+      )
+    ).toContain("redirect dropped or changed query parameter dev");
+  });
+
+  it("rejects expectations for parameters absent from the request", () => {
+    expect(
+      comparePreservedQueryParams(
+        "https://esm.unpkg.com/react@18?dev",
+        "https://esm.unpkg.com/react@18.3.1?dev=",
+        ["external"]
+      )
+    ).toContain("missing request parameter");
+  });
+});
+
+describe("comparePreservedQueryParamsAcrossRedirects", () => {
+  it("checks every redirect destination instead of only the final URL", () => {
+    expect(
+      comparePreservedQueryParamsAcrossRedirects(
+        "https://esm.unpkg.com/react@18?dev",
+        [
+          {
+            location: "/react@18.3.1?target=es2022",
+            url: "https://esm.unpkg.com/react@18?dev",
+          },
+          {
+            location: "/react@18.3.1?dev=&target=es2022",
+            url: "https://esm.unpkg.com/react@18.3.1?target=es2022",
+          },
+        ],
+        "https://esm.unpkg.com/react@18.3.1?dev=&target=es2022",
+        ["dev"]
+      )
+    ).toContain("redirect hop 1");
+  });
+
+  it("reports redirects without Location headers", () => {
+    expect(
+      comparePreservedQueryParamsAcrossRedirects(
+        "https://esm.unpkg.com/react@18?dev",
+        [{ location: null, url: "https://esm.unpkg.com/react@18?dev" }],
+        "https://esm.unpkg.com/react@18?dev",
+        ["dev"]
+      )
+    ).toContain("missing a Location header");
+  });
+});

--- a/scripts/esm-compat-redirects.ts
+++ b/scripts/esm-compat-redirects.ts
@@ -1,0 +1,73 @@
+export function compareFinalPathAndQuery(leftUrl: string, rightUrl: string): string | null {
+  let left = normalizePathAndQuery(leftUrl);
+  let right = normalizePathAndQuery(rightUrl);
+
+  return left === right ? null : `final redirect target mismatch: esm.sh=${left}, esm.unpkg.com=${right}`;
+}
+
+export function comparePreservedQueryParams(
+  requestUrl: string,
+  finalUrl: string,
+  paramNames: readonly string[]
+): string | null {
+  let request = new URL(requestUrl);
+  let final = new URL(finalUrl);
+
+  for (let name of paramNames) {
+    let expected = request.searchParams.getAll(name).sort();
+    if (expected.length === 0) {
+      return `redirect query expectation references missing request parameter: ${name}`;
+    }
+
+    let actual = final.searchParams.getAll(name).sort();
+    if (!equalStrings(expected, actual)) {
+      return `redirect dropped or changed query parameter ${name}: expected=${formatValues(expected)}, actual=${formatValues(actual)}`;
+    }
+  }
+
+  return null;
+}
+
+export function comparePreservedQueryParamsAcrossRedirects(
+  requestUrl: string,
+  redirectChain: readonly { location: string | null; url: string }[],
+  finalUrl: string,
+  paramNames: readonly string[]
+): string | null {
+  for (let [index, hop] of redirectChain.entries()) {
+    if (hop.location == null) {
+      return `redirect hop ${index + 1} is missing a Location header`;
+    }
+
+    let destinationUrl = new URL(hop.location, hop.url).toString();
+    let mismatch = comparePreservedQueryParams(requestUrl, destinationUrl, paramNames);
+    if (mismatch != null) {
+      return `redirect hop ${index + 1}: ${mismatch}`;
+    }
+  }
+
+  let finalMismatch = comparePreservedQueryParams(requestUrl, finalUrl, paramNames);
+  return finalMismatch == null ? null : `final response: ${finalMismatch}`;
+}
+
+function normalizePathAndQuery(value: string): string {
+  let url = new URL(value);
+  let entries = Array.from(url.searchParams.entries()).sort(([leftName, leftValue], [rightName, rightValue]) => {
+    if (leftName === rightName) {
+      return leftValue.localeCompare(rightValue);
+    }
+
+    return leftName.localeCompare(rightName);
+  });
+  let searchParams = new URLSearchParams(entries);
+  let search = searchParams.size === 0 ? "" : `?${searchParams.toString()}`;
+  return `${url.pathname}${search}`;
+}
+
+function equalStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function formatValues(values: readonly string[]): string {
+  return JSON.stringify(values);
+}

--- a/scripts/esm-compat-suite.test.ts
+++ b/scripts/esm-compat-suite.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  compareSummaries,
+  isCompatCase,
+  type CompatCase,
+  type FetchSummary,
+} from "./esm-compat-suite.ts";
+
+const moduleCase: CompatCase = {
+  description: "module",
+  expect: "module",
+  path: "/react@18.3.1",
+};
+
+describe("compareSummaries", () => {
+  it("rejects matching failures for cases that require a successful response", () => {
+    let esmSh = summary({ ok: false, status: 404 });
+    let esmUnpkg = summary({ ok: false, status: 404 });
+
+    expect(compareSummaries(moduleCase, esmSh, esmUnpkg)).toEqual({
+      failureCategory: "unexpected-failure",
+      reason: "expected successful module response from esm.unpkg.com, got 404",
+    });
+  });
+
+  it("accepts failures only when the case expects a diagnostic", () => {
+    let diagnosticCase: CompatCase = {
+      description: "diagnostic",
+      expect: "diagnostic",
+      path: "/missing",
+    };
+    let esmSh = summary({ ok: false, status: 404 });
+    let esmUnpkg = summary({ ok: false, status: 415 });
+
+    expect(compareSummaries(diagnosticCase, esmSh, esmUnpkg)).toEqual({
+      failureCategory: null,
+      reason: null,
+    });
+  });
+
+  it("rejects successful responses with different content kinds", () => {
+    let esmSh = summary({ contentType: "application/javascript", executableModule: true });
+    let esmUnpkg = summary({ contentType: "text/css" });
+
+    expect(compareSummaries(moduleCase, esmSh, esmUnpkg)).toEqual({
+      failureCategory: "content-type-mismatch",
+      reason: "response kind mismatch: esm.sh=javascript, esm.unpkg.com=css",
+    });
+  });
+
+  it("allows a documented content-kind divergence while enforcing the expected UNPKG kind", () => {
+    let cssCase: CompatCase = {
+      contentParity: "expected-only",
+      description: "intentional CSS behavior",
+      expect: "css",
+      path: "/style.css",
+    };
+    let esmSh = summary({ contentType: "application/javascript" });
+    let esmUnpkg = summary({ contentType: "text/css", executableModule: false });
+
+    expect(compareSummaries(cssCase, esmSh, esmUnpkg)).toEqual({ failureCategory: null, reason: null });
+  });
+
+  it("classifies timeouts separately from connectivity failures", () => {
+    let esmSh = summary();
+    let esmUnpkg = summary({ diagnosticCode: "TIMEOUT", ok: false, status: 0 });
+
+    expect(compareSummaries(moduleCase, esmSh, esmUnpkg).failureCategory).toBe("timeout");
+  });
+
+  it("rejects successful responses with different status codes", () => {
+    let esmSh = summary({ status: 200 });
+    let esmUnpkg = summary({ status: 206 });
+
+    expect(compareSummaries(moduleCase, esmSh, esmUnpkg)).toEqual({
+      failureCategory: "status-mismatch",
+      reason: "status mismatch: esm.sh=200, esm.unpkg.com=206",
+    });
+  });
+
+  it("honors the declared TypeScript expectation", () => {
+    let typesCase: CompatCase = {
+      description: "types",
+      expect: "typescript",
+      path: "/@types/react@18.2.0",
+    };
+    let esmSh = summary({ contentType: "application/typescript" });
+    let esmUnpkg = summary({ contentType: "application/typescript" });
+
+    expect(compareSummaries(typesCase, esmSh, esmUnpkg)).toEqual({
+      failureCategory: null,
+      reason: null,
+    });
+  });
+
+  it("does not let matching TypeScript responses override a JSON expectation", () => {
+    let jsonCase: CompatCase = {
+      description: "metadata",
+      expect: "json",
+      path: "/@types/react@18.2.0?meta",
+    };
+    let esmSh = summary({ contentType: "application/typescript" });
+    let esmUnpkg = summary({ contentType: "application/typescript" });
+
+    expect(compareSummaries(jsonCase, esmSh, esmUnpkg).failureCategory).toBe("content-type-mismatch");
+  });
+
+  it("checks UNPKG query preservation even when the baseline is unavailable", () => {
+    let redirectCase: CompatCase = {
+      description: "redirect query",
+      expect: "module",
+      path: "/react@18?dev",
+      preserveRedirectQuery: ["dev"],
+    };
+    let esmSh = summary({ diagnosticCode: "FETCH_ERROR", ok: false, status: 0 });
+    let esmUnpkg = summary({
+      finalUrl: "https://esm.unpkg.com/react@18.3.1?target=es2022",
+      redirectChain: [
+        {
+          location: "/react@18.3.1?target=es2022",
+          status: 302,
+          url: "https://esm.unpkg.com/react@18?dev",
+        },
+      ],
+    });
+
+    expect(compareSummaries(redirectCase, esmSh, esmUnpkg).failureCategory).toBe("redirect-mismatch");
+  });
+
+  it("rejects redirect target differences independent of origin and query order", () => {
+    let redirectCase: CompatCase = {
+      description: "asset redirect",
+      expect: "css",
+      path: "/normalize.css@8.0.1?target=es2020",
+      redirectParity: "final-path-and-query",
+    };
+    let esmSh = summary({
+      contentType: "text/css",
+      finalUrl: "https://esm.sh/normalize.css@8.0.1/normalize.css",
+      redirectChain: [
+        {
+          location: "/normalize.css@8.0.1/normalize.css",
+          status: 301,
+          url: "https://esm.sh/normalize.css@8.0.1?target=es2020",
+        },
+      ],
+    });
+    let esmUnpkg = summary({
+      contentType: "text/css",
+      finalUrl: "https://esm.unpkg.com/normalize.css@8.0.1/normalize.css?target=es2020",
+      redirectChain: [
+        {
+          location: "/normalize.css@8.0.1/normalize.css?target=es2020",
+          status: 301,
+          url: "https://esm.unpkg.com/normalize.css@8.0.1?target=es2020",
+        },
+      ],
+    });
+
+    expect(compareSummaries(redirectCase, esmSh, esmUnpkg).failureCategory).toBe("redirect-mismatch");
+  });
+});
+
+describe("isCompatCase", () => {
+  it("accepts TypeScript and redirect query expectations", () => {
+    expect(
+      isCompatCase({
+        description: "types redirect",
+        expect: "typescript",
+        path: "/@types/react@18.2.0?target=es2020",
+        preserveRedirectQuery: ["target"],
+        redirectParity: "final-path-and-query",
+        contentParity: "expected-only",
+      })
+    ).toBe(true);
+  });
+
+  it("rejects empty query expectations and unknown parity modes", () => {
+    expect(
+      isCompatCase({ description: "empty", expect: "module", path: "/react", preserveRedirectQuery: [] })
+    ).toBe(false);
+    expect(
+      isCompatCase({ description: "mode", expect: "module", path: "/react", redirectParity: "redirect-count" })
+    ).toBe(false);
+    expect(
+      isCompatCase({ description: "content", expect: "module", path: "/react", contentParity: "ignore" })
+    ).toBe(false);
+  });
+});
+
+function summary(overrides: Partial<FetchSummary> = {}): FetchSummary {
+  return {
+    contentLength: 1,
+    contentType: "application/javascript",
+    diagnosticCode: null,
+    durationMs: 1,
+    executableModule: true,
+    finalUrl: "https://example.com/react@18.3.1",
+    headers: {},
+    ok: true,
+    redirectChain: [],
+    status: 200,
+    ...overrides,
+  };
+}

--- a/scripts/esm-compat-suite.test.ts
+++ b/scripts/esm-compat-suite.test.ts
@@ -172,6 +172,7 @@ describe("isCompatCase", () => {
         preserveRedirectQuery: ["target"],
         redirectParity: "final-path-and-query",
         contentParity: "expected-only",
+        exportParity: "expected-only",
       })
     ).toBe(true);
   });
@@ -185,6 +186,9 @@ describe("isCompatCase", () => {
     ).toBe(false);
     expect(
       isCompatCase({ description: "content", expect: "module", path: "/react", contentParity: "ignore" })
+    ).toBe(false);
+    expect(
+      isCompatCase({ description: "exports", expect: "module", path: "/react", exportParity: "ignore" })
     ).toBe(false);
   });
 });

--- a/scripts/esm-compat-suite.ts
+++ b/scripts/esm-compat-suite.ts
@@ -23,6 +23,7 @@ export interface CompatCase {
   contentParity?: "expected-only";
   description: string;
   expect: ExpectedBehavior;
+  exportParity?: "expected-only";
   features?: string[];
   package?: string;
   path: string;
@@ -779,6 +780,7 @@ export function isCompatCase(value: unknown): value is CompatCase {
   let preserveRedirectQuery = compatCase.preserveRedirectQuery;
   let redirectParity = compatCase.redirectParity;
   let contentParity = compatCase.contentParity;
+  let exportParity = compatCase.exportParity;
   return (
     typeof compatCase.description === "string" &&
     typeof compatCase.path === "string" &&
@@ -788,6 +790,7 @@ export function isCompatCase(value: unknown): value is CompatCase {
         preserveRedirectQuery.every((name) => typeof name === "string" && name !== ""))) &&
     (redirectParity == null || redirectParity === "final-path-and-query") &&
     (contentParity == null || contentParity === "expected-only") &&
+    (exportParity == null || exportParity === "expected-only") &&
     (compatCase.expect === "module" ||
       compatCase.expect === "javascript" ||
       compatCase.expect === "json" ||

--- a/scripts/esm-compat-suite.ts
+++ b/scripts/esm-compat-suite.ts
@@ -2,7 +2,9 @@
 
 import { readFile } from "node:fs/promises";
 
-type ExpectedBehavior = "module" | "json" | "css" | "redirect" | "diagnostic";
+import { compareFinalPathAndQuery, comparePreservedQueryParamsAcrossRedirects } from "./esm-compat-redirects.ts";
+
+type ExpectedBehavior = "module" | "javascript" | "json" | "css" | "typescript" | "redirect" | "diagnostic";
 type FailureCategory =
   | "content-type-mismatch"
   | "diagnostic"
@@ -10,16 +12,22 @@ type FailureCategory =
   | "ok-mismatch"
   | "redirect-mismatch"
   | "server-error"
+  | "status-mismatch"
+  | "timeout"
+  | "unexpected-failure"
   | "unexpected-success";
 type OutputMode = "json" | "ndjson" | "text";
 
-interface CompatCase {
+export interface CompatCase {
   category?: string;
+  contentParity?: "expected-only";
   description: string;
   expect: ExpectedBehavior;
   features?: string[];
   package?: string;
   path: string;
+  preserveRedirectQuery?: string[];
+  redirectParity?: "final-path-and-query";
 }
 
 interface CompatCorpus {
@@ -34,7 +42,7 @@ interface RedirectHop {
   url: string;
 }
 
-interface FetchSummary {
+export interface FetchSummary {
   contentLength: number;
   contentType: string | null;
   diagnosticCode: string | null;
@@ -147,45 +155,52 @@ const defaultCorpusPath = "scripts/esm-compat-corpus.seed.json";
 const defaultTimeoutMs = 15_000;
 const maxFetchRetries = 1;
 
-let options = parseArgs(process.argv.slice(2));
 let esmShOrigin = stripTrailingSlash(process.env.ESM_SH_ORIGIN ?? "https://esm.sh");
 let esmUnpkgOrigin = stripTrailingSlash(process.env.ESM_UNPKG_ORIGIN ?? "https://esm.unpkg.com");
 let filesOrigin = stripTrailingSlash(process.env.ESM_FILES_ORIGIN ?? "http://localhost:4000");
-let corpus = await loadCorpus(options.corpusPath);
-let reportBase: Omit<CompatReport, "results" | "summary"> = {
-  comparedAt: new Date().toISOString(),
-  corpus: {
-    caseCount: corpus.cases.length,
-    description: corpus.description,
-    name: corpus.name ?? (options.corpusPath == null ? "default" : options.corpusPath),
-  },
-  origins: {
-    esmSh: esmShOrigin,
-    esmUnpkg: esmUnpkgOrigin,
-  },
-};
-let reporter = createReporter(options.outputMode);
-reporter.start(reportBase, corpus.cases.length);
-let results = options.dryRun
-  ? corpus.cases.map((compatCase, index) => createDryRunResult(compatCase, index))
-  : await runCases(corpus.cases, options, reporter);
-if (options.dryRun) {
-  let dryRunSummary = createEmptySummary(results.length);
-  for (let result of results) {
-    addResultToSummary(dryRunSummary, result);
-    reporter.result(result, dryRunSummary);
-  }
+
+if (import.meta.main) {
+  await main();
 }
-let report: CompatReport = {
-  ...reportBase,
-  results,
-  summary: summarizeResults(results),
-};
 
-reporter.summary(report);
+async function main(): Promise<void> {
+  let options = parseArgs(process.argv.slice(2));
+  let corpus = await loadCorpus(options.corpusPath);
+  let reportBase: Omit<CompatReport, "results" | "summary"> = {
+    comparedAt: new Date().toISOString(),
+    corpus: {
+      caseCount: corpus.cases.length,
+      description: corpus.description,
+      name: corpus.name ?? (options.corpusPath == null ? "default" : options.corpusPath),
+    },
+    origins: {
+      esmSh: esmShOrigin,
+      esmUnpkg: esmUnpkgOrigin,
+    },
+  };
+  let reporter = createReporter(options.outputMode);
+  reporter.start(reportBase, corpus.cases.length);
+  let results = options.dryRun
+    ? corpus.cases.map((compatCase, index) => createDryRunResult(compatCase, index))
+    : await runCases(corpus.cases, options, reporter);
+  if (options.dryRun) {
+    let dryRunSummary = createEmptySummary(results.length);
+    for (let result of results) {
+      addResultToSummary(dryRunSummary, result);
+      reporter.result(result, dryRunSummary);
+    }
+  }
+  let report: CompatReport = {
+    ...reportBase,
+    results,
+    summary: summarizeResults(results),
+  };
 
-if (!options.dryRun && report.summary.failed > 0) {
-  process.exitCode = 1;
+  reporter.summary(report);
+
+  if (!options.dryRun && report.summary.failed > 0) {
+    process.exitCode = 1;
+  }
 }
 
 async function loadCorpus(corpusPath: string | null): Promise<CompatCorpus> {
@@ -357,7 +372,7 @@ function withTimeout(
       resolve({
         contentLength: 0,
         contentType: null,
-        diagnosticCode: "FETCH_ERROR",
+        diagnosticCode: "TIMEOUT",
         durationMs: Math.round(performance.now() - startedAt),
         executableModule: false,
         finalUrl: url.toString(),
@@ -400,7 +415,7 @@ async function summarizeResponse(
   };
 }
 
-function compareSummaries(
+export function compareSummaries(
   compatCase: CompatCase,
   esmSh: FetchSummary,
   esmUnpkg: FetchSummary
@@ -412,12 +427,11 @@ function compareSummaries(
     };
   }
 
-  if (esmSh.diagnosticCode === "FETCH_ERROR" || esmSh.status >= 500) {
-    return validateExpectedBehavior(compatCase, esmUnpkg);
-  }
-
-  if (compatCase.expect === "diagnostic") {
-    return validateExpectedBehavior(compatCase, esmUnpkg);
+  if (esmUnpkg.diagnosticCode === "TIMEOUT") {
+    return {
+      failureCategory: "timeout",
+      reason: `request timed out: esm.sh=${esmSh.status}, esm.unpkg.com=${esmUnpkg.status}`,
+    };
   }
 
   if (esmUnpkg.status >= 500) {
@@ -427,6 +441,50 @@ function compareSummaries(
     };
   }
 
+  if (compatCase.preserveRedirectQuery != null) {
+    if (esmUnpkg.redirectChain.length === 0) {
+      return {
+        failureCategory: "redirect-mismatch",
+        reason: "expected esm.unpkg.com redirect chain for query preservation check",
+      };
+    }
+
+    let queryMismatch = comparePreservedQueryParamsAcrossRedirects(
+      new URL(compatCase.path, esmUnpkg.redirectChain[0]?.url ?? esmUnpkg.finalUrl).toString(),
+      esmUnpkg.redirectChain,
+      esmUnpkg.finalUrl,
+      compatCase.preserveRedirectQuery
+    );
+    if (queryMismatch != null) {
+      return { failureCategory: "redirect-mismatch", reason: queryMismatch };
+    }
+  }
+
+  if (esmSh.diagnosticCode === "FETCH_ERROR" || esmSh.diagnosticCode === "TIMEOUT" || esmSh.status >= 500) {
+    return validateExpectedBehavior(compatCase, esmUnpkg);
+  }
+
+  if (compatCase.expect === "diagnostic") {
+    return validateExpectedBehavior(compatCase, esmUnpkg);
+  }
+
+  if (
+    compatCase.redirectParity === "final-path-and-query" &&
+    esmSh.diagnosticCode !== "FETCH_ERROR"
+  ) {
+    if (esmSh.redirectChain.length === 0 || esmUnpkg.redirectChain.length === 0) {
+      return {
+        failureCategory: "redirect-mismatch",
+        reason: `expected redirect chains for final target comparison: esm.sh=${esmSh.redirectChain.length}, esm.unpkg.com=${esmUnpkg.redirectChain.length}`,
+      };
+    }
+
+    let redirectMismatch = compareFinalPathAndQuery(esmSh.finalUrl, esmUnpkg.finalUrl);
+    if (redirectMismatch != null) {
+      return { failureCategory: "redirect-mismatch", reason: redirectMismatch };
+    }
+  }
+
   if (esmSh.ok !== esmUnpkg.ok) {
     return {
       failureCategory: esmUnpkg.diagnosticCode == null ? "ok-mismatch" : "diagnostic",
@@ -434,17 +492,24 @@ function compareSummaries(
     };
   }
 
-  if (!esmSh.ok && !esmUnpkg.ok) {
-    return { failureCategory: null, reason: null };
+  if (esmSh.status !== esmUnpkg.status) {
+    return {
+      failureCategory: "status-mismatch",
+      reason: `status mismatch: esm.sh=${esmSh.status}, esm.unpkg.com=${esmUnpkg.status}`,
+    };
   }
 
-  if (esmSh.ok && isTypeScript(esmSh.contentType)) {
-    return isTypeScript(esmUnpkg.contentType)
-      ? { failureCategory: null, reason: null }
-      : {
-          failureCategory: "content-type-mismatch",
-          reason: `expected TypeScript from esm.unpkg.com, got ${esmUnpkg.contentType ?? "missing content type"}`,
-        };
+  if (!esmSh.ok && !esmUnpkg.ok) {
+    return validateExpectedBehavior(compatCase, esmUnpkg);
+  }
+
+  let esmShContentKind = getContentKind(esmSh.contentType);
+  let esmUnpkgContentKind = getContentKind(esmUnpkg.contentType);
+  if (compatCase.contentParity !== "expected-only" && esmShContentKind !== esmUnpkgContentKind) {
+    return {
+      failureCategory: "content-type-mismatch",
+      reason: `response kind mismatch: esm.sh=${esmShContentKind}, esm.unpkg.com=${esmUnpkgContentKind}`,
+    };
   }
 
   return validateExpectedBehavior(compatCase, esmUnpkg);
@@ -463,6 +528,13 @@ function validateExpectedBehavior(
         };
   }
 
+  if (!esmUnpkg.ok) {
+    return {
+      failureCategory: "unexpected-failure",
+      reason: `expected successful ${compatCase.expect} response from esm.unpkg.com, got ${esmUnpkg.status}`,
+    };
+  }
+
   if (compatCase.expect === "json" && !isJson(esmUnpkg.contentType)) {
     return {
       failureCategory: "content-type-mismatch",
@@ -474,6 +546,20 @@ function validateExpectedBehavior(
     return {
       failureCategory: "content-type-mismatch",
       reason: `expected CSS from esm.unpkg.com, got ${esmUnpkg.contentType ?? "missing content type"}`,
+    };
+  }
+
+  if (compatCase.expect === "typescript" && !isTypeScript(esmUnpkg.contentType)) {
+    return {
+      failureCategory: "content-type-mismatch",
+      reason: `expected TypeScript from esm.unpkg.com, got ${esmUnpkg.contentType ?? "missing content type"}`,
+    };
+  }
+
+  if (compatCase.expect === "javascript" && !isJavaScript(esmUnpkg.contentType)) {
+    return {
+      failureCategory: "content-type-mismatch",
+      reason: `expected JavaScript from esm.unpkg.com, got ${esmUnpkg.contentType ?? "missing content type"}`,
     };
   }
 
@@ -684,18 +770,29 @@ function isCompatCorpus(value: unknown): value is CompatCorpus {
   return Array.isArray(corpus.cases) && corpus.cases.every(isCompatCase);
 }
 
-function isCompatCase(value: unknown): value is CompatCase {
+export function isCompatCase(value: unknown): value is CompatCase {
   if (typeof value !== "object" || value == null) {
     return false;
   }
 
   let compatCase = value as Record<string, unknown>;
+  let preserveRedirectQuery = compatCase.preserveRedirectQuery;
+  let redirectParity = compatCase.redirectParity;
+  let contentParity = compatCase.contentParity;
   return (
     typeof compatCase.description === "string" &&
     typeof compatCase.path === "string" &&
+    (preserveRedirectQuery == null ||
+      (Array.isArray(preserveRedirectQuery) &&
+        preserveRedirectQuery.length > 0 &&
+        preserveRedirectQuery.every((name) => typeof name === "string" && name !== ""))) &&
+    (redirectParity == null || redirectParity === "final-path-and-query") &&
+    (contentParity == null || contentParity === "expected-only") &&
     (compatCase.expect === "module" ||
+      compatCase.expect === "javascript" ||
       compatCase.expect === "json" ||
       compatCase.expect === "css" ||
+      compatCase.expect === "typescript" ||
       compatCase.expect === "redirect" ||
       compatCase.expect === "diagnostic")
   );
@@ -756,28 +853,39 @@ function isJavaScript(contentType: string | null): boolean {
   return contentType?.includes("javascript") || contentType?.includes("ecmascript") || false;
 }
 
+function getContentKind(contentType: string | null): "css" | "javascript" | "json" | "typescript" | "other" {
+  if (isCss(contentType)) return "css";
+  if (isJavaScript(contentType)) return "javascript";
+  if (isJson(contentType)) return "json";
+  if (isTypeScript(contentType)) return "typescript";
+  return "other";
+}
+
 function stripTrailingSlash(value: string): string {
   return value.replace(/\/+$/, "");
 }
 
 function createLocalServices(options: RunOptions, reporter: Reporter) {
+  let esmUnpkgService = createManagedService("esm.unpkg", esmUnpkgOrigin, "/_health", [
+    "pnpm",
+    "--filter",
+    "unpkg-esm",
+    "exec",
+    "wrangler",
+    "dev",
+    "--env",
+    "dev",
+    "--port",
+    "3002",
+    "--ip",
+    "127.0.0.1",
+  ]);
   let services = [
     createManagedService("esm.sh", esmShOrigin, "/react@18.3.1", ["pnpm", "vendor:esm-sh"]),
-    createManagedService("esm.unpkg", esmUnpkgOrigin, "/_health", [
-      "pnpm",
-      "--filter",
-      "unpkg-esm",
-      "exec",
-      "wrangler",
-      "dev",
-      "--env",
-      "dev",
-      "--port",
-      "3002",
-      "--ip",
-      "127.0.0.1",
-    ]),
-    createManagedService("unpkg-files", filesOrigin, "/_health", ["pnpm", "--filter", "unpkg-files", "dev"]),
+    esmUnpkgService,
+    esmUnpkgService == null
+      ? null
+      : createManagedService("unpkg-files", filesOrigin, "/_health", ["pnpm", "--filter", "unpkg-files", "dev"]),
   ].filter((service): service is ManagedService => service != null);
   let restarts = new Map<string, Promise<boolean>>();
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -2,6 +2,9 @@
   "name": "unpkg-scripts",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test": "bun test"
+  },
   "dependencies": {
     "@types/node": "^22.10.2",
     "chalk": "^5.4.1",


### PR DESCRIPTION
This closes esm.sh parity gaps in URL normalization, redirect-to-asset behavior, and statically discoverable module exports, then turns those cases into repeatable HTTP and Chromium comparison gates.

- compare every redirect hop for query preservation, final asset paths/queries, response status and kind, diagnostics, and timeouts
- resolve raw package roots, conditional exports, scoped and extensionless subpaths, CSS entries, and declaration assets to the same canonical targets as esm.sh
- use esm.sh's SWC-based `@esm.sh/cjs-module-lexer` instead of regex source analysis, including recursive local CommonJS re-exports and environment-specific entry selection
- resolve wildcard package exports so ESM self-references such as Zustand, Valtio, and Jotai stay on their ESM entry graph
- avoid named-export bindings that shadow globals used by bundled CommonJS source
- implement `?exports` tree shaking for ESM through a synthetic esbuild entry
- compare runtime export surfaces directly against esm.sh with the browser runner's `--baseline-origin` option
- keep package analysis fully static: Lodash remains default-only because its named-export object is constructed at runtime, and the corpus records that intentional divergence

Run the complete candidate-versus-baseline workflows with:

```sh
ESM_UNPKG_ORIGIN=http://localhost:3002 pnpm test:esm-compat -- --corpus scripts/esm-compat-corpus.ecosystem.json --timeout-ms 60000
pnpm test:esm-browser -- --corpus scripts/esm-compat-corpus.medium.json --origin http://localhost:3002 --baseline-origin https://esm.sh --limit 100
```

Fixes #461
