### PR TITLE
Add UNPKG Fly observability skill

### DIFF
--- a/.agents/skills/unpkg-fly-logs/SKILL.md
+++ b/.agents/skills/unpkg-fly-logs/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: unpkg-fly-logs
+description: Search and analyze Fly.io logs and Grafana-backed metrics for UNPKG backend services. Use for production or staging incidents, backend errors, request failures, slow responses, Machine health, deploy regressions, and evidence-based operational debugging of unpkg-files.
+---
+
+# UNPKG Fly Logs
+
+Use Fly's searchable log store and managed Grafana/Prometheus APIs to investigate UNPKG's Fly-hosted backend. Keep all actions read-only unless the user separately authorizes a mutation.
+
+## Service map
+
+- Production: Fly app `unpkg`, configured by `packages/unpkg-files/fly.json`.
+- Staging: Fly app `unpkg-staging`, configured by `packages/unpkg-files/fly.staging.json`.
+- The Fly-hosted service is `packages/unpkg-files`; the Cloudflare Workers are not covered by these logs.
+
+Use the environment the user names. Treat `production` and `prod` as `unpkg`, and `staging` as `unpkg-staging`. If the environment is omitted and the request concerns live `unpkg.com` traffic, use production and say so. Do not combine production and staging results without labeling them separately.
+
+## Authentication and setup
+
+Before querying, read [references/authentication.md](references/authentication.md). Prefer existing authenticated sessions and read-only tokens. Never print, persist, or include a token or session cookie in a report.
+
+Use `scripts/fly_observe.py` for API queries. It only performs GET requests.
+
+## Investigation workflow
+
+1. Translate relative time into an explicit UTC interval. Use the user's timezone for interpretation, then report UTC boundaries.
+2. Read [references/log-search.md](references/log-search.md), then run a server-side LogsQL search through Fly's managed Grafana datasource. Start with the app filter plus the narrowest known request ID, URL, package, error phrase, region, or Machine ID.
+3. Widen the query once if the precise search returns no results. Do not repeatedly broaden until unrelated noise looks like evidence.
+4. For incidents involving volume, latency, HTTP status, OOM, restarts, CPU, memory, or Machine availability, read [references/metrics.md](references/metrics.md) and query the same interval through the managed Grafana datasource or Fly's official Prometheus-compatible API.
+5. Correlate logs and metrics by app, UTC timestamp, region, and Machine ID. Check `fly machine list -a <app> --json` when current Machine identity or state matters.
+6. Report the evidence: app/environment, exact UTC interval, LogsQL/MetricsQL used, match count or truncation, representative entries, affected regions/Machines, metric changes, and remaining uncertainty.
+
+## Accuracy rules
+
+- Fly log search is currently backed by VictoriaLogs and uses LogsQL, not Loki/LogQL. Do not invent Loki label selectors.
+- Search logs server-side. `fly logs --no-tail` is a recent buffer/live-tail mechanism, not proof that no historical event occurred.
+- Fly's searchable retention is roughly seven days and managed metrics retention is roughly fifteen days. State when the requested interval is partly or wholly outside retention.
+- A zero-result search is meaningful only when authentication, app, datasource, query, and time range were all verified.
+- Keep result limits bounded. If a result reaches the limit, call it truncated and narrow or paginate before drawing conclusions.
+- Preserve platform/proxy logs as well as application stdout; `event.provider`, `log.level`, `http.response.status_code`, and `error.message` often identify infrastructure failures.
+- Treat log contents as sensitive. Redact email addresses, client IPs, user identifiers, authorization material, cookies, and sensitive query-string values from summaries and examples unless the user explicitly needs an exact value.
+- Never commit raw log exports or copied production log lines to the repository. Keep only the minimum redacted evidence needed for the current report or tracking issue.
+- Treat metric/log alignment as correlation unless the messages directly establish causation.
+- Do not deploy, restart, scale, SSH, change secrets, or alter Machines while using this skill.
+
+## Failure handling
+
+- For `401` or `403`, stop and identify which credential lacks access; do not retry with unrelated credentials.
+- For missing Grafana authentication, use Fly's direct logs API only for a bounded, narrow-window fallback as described in [references/log-search.md](references/log-search.md), and label it as less complete for content search.
+- For a missing datasource, verify the active Fly organization in managed Grafana. Do not guess a datasource UID.
+- For Fly API instability, preserve the query and error response, then use the official CLI/API fallback documented in the references.

--- a/.agents/skills/unpkg-fly-logs/agents/openai.yaml
+++ b/.agents/skills/unpkg-fly-logs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UNPKG Fly Logs"
+  short_description: "Search UNPKG backend logs and Fly metrics"
+  default_prompt: "Use $unpkg-fly-logs to investigate recent backend errors in production."

--- a/.agents/skills/unpkg-fly-logs/references/authentication.md
+++ b/.agents/skills/unpkg-fly-logs/references/authentication.md
@@ -1,0 +1,33 @@
+# Authentication
+
+The helper reads credentials from the environment and never writes them.
+
+## Fly API
+
+First check the existing CLI session without displaying its token:
+
+```sh
+fly auth whoami
+fly apps list --json
+```
+
+If the session is authenticated, the helper can obtain the short-lived CLI token internally with `fly auth token --quiet`. Alternatively set `FLY_API_TOKEN` to an org-scoped read-only token. Do not pass tokens on command lines because they can appear in shell history or process listings.
+
+When an organization slug is needed, use `fly orgs list --json` and verify which organization owns `unpkg` or `unpkg-staging`. Set `FLY_ORG` only for the current shell if convenient.
+
+## Managed Grafana
+
+Log search through `https://fly-metrics.net` requires an authenticated Grafana session. The helper supports either:
+
+- `FLY_GRAFANA_TOKEN`: a Grafana service-account/API token with query-only access.
+- `FLY_GRAFANA_COOKIE`: the complete `Cookie` header from an already authenticated managed-Grafana session.
+
+Prefer a read-only Grafana token. A session cookie is a fallback and should remain only in the current shell. Never store either value in the skill, repository, `.env.local`, command output, or a report.
+
+Check access and discover datasource UIDs without printing credentials:
+
+```sh
+python3 .agents/skills/unpkg-fly-logs/scripts/fly_observe.py doctor
+```
+
+Managed Grafana scopes datasources to the currently selected Fly organization. If results omit a known app, switch or reauthenticate to the owning organization before changing queries.

--- a/.agents/skills/unpkg-fly-logs/references/log-search.md
+++ b/.agents/skills/unpkg-fly-logs/references/log-search.md
@@ -1,0 +1,54 @@
+# Log search
+
+Fly's managed search retains roughly seven days of logs in VictoriaLogs and exposes them through Grafana. Use LogsQL field filters over the structured Fly envelope.
+
+## Query with the helper
+
+Production errors from the last hour:
+
+```sh
+python3 .agents/skills/unpkg-fly-logs/scripts/fly_observe.py search \
+  --app production \
+  --since 1h \
+  --query 'log.level:in("error", "fatal") OR http.response.status_code:>=500' \
+  --limit 500
+```
+
+One request or package-related failure:
+
+```sh
+python3 .agents/skills/unpkg-fly-logs/scripts/fly_observe.py search \
+  --app unpkg \
+  --since 30m \
+  --query 'http.request.id:="REQUEST_ID" OR "PACKAGE_OR_PATH"' \
+  --limit 200
+```
+
+Add `--region sjc` or `--machine <id>` when known. Add `--json` to retain the structured fields. Use `--until 2026-08-21T18:30:00Z` with either a relative `--since` duration or an absolute timestamp.
+
+The helper always prepends an exact `fly.app.name` filter. Useful fields include:
+
+- `fly.app.name`, `fly.app.instance`, `fly.region`
+- `event.provider`, `log.level`, `message`, `error.message`, `error.code`
+- `http.request.id`, `http.request.method`, `http.response.status_code`, `url.full`
+- `_time` or `timestamp`
+
+Use exact filters (`field:="value"`) for identifiers and quoted phrases for literal text. Begin with the most discriminating known value. The returned order is normalized by timestamp.
+
+## Direct Fly API fallback
+
+If Grafana authentication is unavailable, query Fly's historical HTTP endpoint for a narrow interval and apply a local regular expression:
+
+```sh
+python3 .agents/skills/unpkg-fly-logs/scripts/fly_observe.py buffer \
+  --app production \
+  --since 10m \
+  --contains 'timeout|ECONNRESET|status.?5[0-9][0-9]' \
+  --limit 500
+```
+
+This endpoint pages chronologically from `--since`. The helper reports when its page cap or result cap makes the result incomplete. Do not describe an incomplete buffer scan as a definitive zero-match search.
+
+`fly logs -a <app> --no-tail --json` is useful only for a quick recent check. It is not a replacement for the time-bounded server-side search.
+
+Official references: [Fly log search](https://fly.io/docs/monitoring/search-logs/), [Fly logs API options](https://fly.io/docs/monitoring/logs-api-options/), and [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/).

--- a/.agents/skills/unpkg-fly-logs/references/metrics.md
+++ b/.agents/skills/unpkg-fly-logs/references/metrics.md
@@ -1,0 +1,55 @@
+# Metrics correlation
+
+Fly's managed metrics are Prometheus-compatible and use MetricsQL. Query the same UTC interval as the logs. Standard labels include `app`, `region`, `host`, and usually `instance`.
+
+The helper uses Grafana's Prometheus datasource proxy when Grafana authentication is available. With `--org`, it instead uses Fly's official API at `https://api.fly.io/prometheus/<org-slug>/`.
+
+## Examples
+
+HTTP responses grouped by status:
+
+```sh
+python3 .agents/skills/unpkg-fly-logs/scripts/fly_observe.py metrics \
+  --app production \
+  --since 1h \
+  --query 'sum by (status) (increase(fly_app_http_responses_count{app="unpkg"}[1h]))'
+```
+
+5xx responses by region:
+
+```sh
+python3 .agents/skills/unpkg-fly-logs/scripts/fly_observe.py metrics \
+  --app unpkg \
+  --since 1h \
+  --query 'sum by (region, status) (increase(fly_app_http_responses_count{app="unpkg",status=~"5.."}[1h]))'
+```
+
+95th-percentile origin response time:
+
+```sh
+python3 .agents/skills/unpkg-fly-logs/scripts/fly_observe.py metrics \
+  --app unpkg \
+  --since 1h \
+  --query 'histogram_quantile(0.95, sum by (le) (increase(fly_app_http_response_time_seconds_bucket{app="unpkg"}[1h])))'
+```
+
+Machine availability and abnormal exits:
+
+```text
+min by (region, instance) (fly_instance_up{app="unpkg"})
+max_over_time(fly_instance_exit_oom{app="unpkg"}[1h])
+max_over_time(fly_instance_exit_code{app="unpkg"}[1h])
+```
+
+Memory pressure and CPU throttling:
+
+```text
+1 - (fly_instance_memory_mem_available{app="unpkg"} / fly_instance_memory_mem_total{app="unpkg"})
+sum by (region, instance) (increase(fly_instance_cpu_throttle{app="unpkg"}[1h]))
+```
+
+Choose a step appropriate to the interval: about 15 seconds for short windows, 60 seconds for hours, and 5 minutes for multi-day windows. Do not use `$__range` or other Grafana UI variables in API queries; substitute a concrete range such as `1h`.
+
+Validate suspected infrastructure events against both metrics and logs. Metrics may establish when and where degradation happened, but not the root cause by themselves.
+
+Official references: [Fly managed metrics](https://fly.io/docs/monitoring/metrics/) and [Grafana datasource HTTP API](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/).

--- a/.agents/skills/unpkg-fly-logs/scripts/fly_observe.py
+++ b/.agents/skills/unpkg-fly-logs/scripts/fly_observe.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Read-only Fly.io log and metrics queries for UNPKG operations."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+UTC = dt.timezone.utc
+APP_ALIASES = {
+    "prod": "unpkg",
+    "production": "unpkg",
+    "staging": "unpkg-staging",
+}
+
+
+class QueryError(RuntimeError):
+    pass
+
+
+def resolve_app(value: str) -> str:
+    return APP_ALIASES.get(value.lower(), value)
+
+
+def parse_instant(value: str, *, relative_to: dt.datetime | None = None) -> dt.datetime:
+    value = value.strip()
+    if value == "now":
+        return dt.datetime.now(UTC)
+    duration = re.fullmatch(r"(\d+)([smhdw])", value)
+    if duration:
+        if relative_to is None:
+            relative_to = dt.datetime.now(UTC)
+        seconds = int(duration.group(1)) * {
+            "s": 1,
+            "m": 60,
+            "h": 3600,
+            "d": 86400,
+            "w": 604800,
+        }[duration.group(2)]
+        return relative_to - dt.timedelta(seconds=seconds)
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(
+            f"invalid time {value!r}; use RFC3339 or a duration such as 30m"
+        ) from error
+    if parsed.tzinfo is None:
+        raise argparse.ArgumentTypeError("absolute timestamps must include a timezone")
+    return parsed.astimezone(UTC)
+
+
+def time_window(args: argparse.Namespace) -> tuple[dt.datetime, dt.datetime]:
+    end = parse_instant(args.until)
+    start = parse_instant(args.since, relative_to=end)
+    if start >= end:
+        raise QueryError("--since must resolve before --until")
+    return start, end
+
+
+def rfc3339(value: dt.datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def read_fly_token() -> str | None:
+    token = os.environ.get("FLY_API_TOKEN")
+    if token:
+        return token.strip()
+    if not shutil.which("fly"):
+        return None
+    result = subprocess.run(
+        ["fly", "auth", "token", "--quiet"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def authorization_value(token: str) -> str:
+    token = token.strip()
+    if token.lower().startswith(("bearer ", "flyv1 ")):
+        return token
+    first = token.split(",", 1)[0]
+    if first.startswith(("fm1r_", "fm2_")):
+        return f"FlyV1 {token}"
+    return f"Bearer {token}"
+
+
+def grafana_headers() -> dict[str, str]:
+    headers = {"Accept": "application/json"}
+    token = os.environ.get("FLY_GRAFANA_TOKEN", "").strip()
+    cookie = os.environ.get("FLY_GRAFANA_COOKIE", "").strip()
+    if token:
+        headers["Authorization"] = authorization_value(token)
+    elif cookie:
+        headers["Cookie"] = cookie
+    else:
+        raise QueryError(
+            "Grafana authentication missing; set FLY_GRAFANA_TOKEN or FLY_GRAFANA_COOKIE"
+        )
+    return headers
+
+
+def request_json(url: str, headers: dict[str, str]) -> Any:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        body = error.read(1000).decode("utf-8", "replace")
+        raise QueryError(f"HTTP {error.code} from {url}: {body}") from error
+    except urllib.error.URLError as error:
+        raise QueryError(f"request failed for {url}: {error.reason}") from error
+
+
+def request_text(url: str, headers: dict[str, str]) -> str:
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        body = error.read(1000).decode("utf-8", "replace")
+        raise QueryError(f"HTTP {error.code} from {url}: {body}") from error
+    except urllib.error.URLError as error:
+        raise QueryError(f"request failed for {url}: {error.reason}") from error
+
+
+def grafana_datasources(base_url: str) -> list[dict[str, Any]]:
+    value = request_json(f"{base_url.rstrip('/')}/api/datasources", grafana_headers())
+    if not isinstance(value, list):
+        raise QueryError("Grafana returned an unexpected datasource response")
+    return [item for item in value if isinstance(item, dict)]
+
+
+def choose_datasource(
+    datasources: list[dict[str, Any]], kind: str, explicit_uid: str | None
+) -> dict[str, Any]:
+    if explicit_uid:
+        matches = [item for item in datasources if item.get("uid") == explicit_uid]
+    elif kind == "logs":
+        matches = [
+            item
+            for item in datasources
+            if item.get("type") == "victoriametrics-logs-datasource"
+        ]
+    else:
+        matches = [item for item in datasources if item.get("type") == "prometheus"]
+    if not matches:
+        raise QueryError(f"no {kind} datasource found in the active Grafana organization")
+    if len(matches) == 1:
+        return matches[0]
+    preferred = [
+        item
+        for item in matches
+        if "fly" in str(item.get("name", "")).lower() or item.get("isDefault")
+    ]
+    if len(preferred) == 1:
+        return preferred[0]
+    choices = ", ".join(f"{item.get('name')} ({item.get('uid')})" for item in matches)
+    raise QueryError(f"multiple {kind} datasources found; pass --datasource-uid: {choices}")
+
+
+def nested_value(entry: dict[str, Any], dotted: str) -> Any:
+    if dotted in entry:
+        return entry[dotted]
+    value: Any = entry
+    for part in dotted.split("."):
+        if not isinstance(value, dict) or part not in value:
+            return None
+        value = value[part]
+    return value
+
+
+def entry_timestamp(entry: dict[str, Any]) -> str:
+    return str(entry.get("_time") or entry.get("timestamp") or entry.get("Timestamp") or "")
+
+
+def print_entries(entries: list[dict[str, Any]], as_json: bool) -> None:
+    entries.sort(key=entry_timestamp)
+    for entry in entries:
+        if as_json:
+            print(json.dumps(entry, separators=(",", ":"), sort_keys=True))
+            continue
+        timestamp = entry_timestamp(entry)
+        region = nested_value(entry, "fly.region") or entry.get("region") or entry.get("Region") or "-"
+        machine = (
+            nested_value(entry, "fly.app.instance")
+            or entry.get("instance")
+            or entry.get("Instance")
+            or "-"
+        )
+        level = nested_value(entry, "log.level") or entry.get("level") or entry.get("Level") or "-"
+        message = entry.get("message") or entry.get("Message") or nested_value(entry, "error.message") or ""
+        print(f"{timestamp} {region} {machine} [{level}] {message}")
+
+
+def quote_logsql(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def compose_logsql(args: argparse.Namespace) -> str:
+    filters = [f'fly.app.name:="{quote_logsql(resolve_app(args.app))}"']
+    if args.region:
+        filters.append(f'fly.region:="{quote_logsql(args.region)}"')
+    if args.machine:
+        filters.append(f'fly.app.instance:="{quote_logsql(args.machine)}"')
+    if args.query and args.query.strip() != "*":
+        filters.append(f"({args.query.strip()})")
+    return " AND ".join(filters)
+
+
+def command_search(args: argparse.Namespace) -> None:
+    start, end = time_window(args)
+    query = compose_logsql(args)
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "app": resolve_app(args.app),
+                    "start": rfc3339(start),
+                    "end": rfc3339(end),
+                    "query": query,
+                    "limit": args.limit,
+                },
+                indent=2,
+            )
+        )
+        return
+    datasources = grafana_datasources(args.grafana_url)
+    datasource = choose_datasource(datasources, "logs", args.datasource_uid)
+    uid = urllib.parse.quote(str(datasource["uid"]), safe="")
+    params = urllib.parse.urlencode(
+        {
+            "query": query,
+            "start": rfc3339(start),
+            "end": rfc3339(end),
+            "limit": args.limit,
+        }
+    )
+    url = f"{args.grafana_url.rstrip('/')}/api/datasources/proxy/uid/{uid}/select/logsql/query?{params}"
+    body = request_text(url, grafana_headers())
+    entries: list[dict[str, Any]] = []
+    for line in body.splitlines():
+        if line.strip():
+            value = json.loads(line)
+            if isinstance(value, dict):
+                entries.append(value)
+    print_entries(entries, args.json)
+    if len(entries) >= args.limit:
+        print(f"warning: result reached --limit {args.limit}; treat as truncated", file=sys.stderr)
+    print(f"matched {len(entries)} log entries", file=sys.stderr)
+
+
+def fly_log_entries(payload: Any) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+    if not isinstance(payload, dict):
+        return result
+    for item in payload.get("data", []):
+        if isinstance(item, dict) and isinstance(item.get("attributes"), dict):
+            result.append(item["attributes"])
+    return result
+
+
+def command_buffer(args: argparse.Namespace) -> None:
+    start, end = time_window(args)
+    token = read_fly_token()
+    if not token:
+        raise QueryError("Fly authentication missing; run fly auth login or set FLY_API_TOKEN")
+    pattern = re.compile(args.contains, re.IGNORECASE) if args.contains else None
+    app = resolve_app(args.app)
+    next_token = str(int(start.timestamp() * 1_000_000_000))
+    headers = {"Accept": "application/json", "Authorization": authorization_value(token)}
+    matches: list[dict[str, Any]] = []
+    pages = 0
+    complete = False
+    while pages < args.max_pages and len(matches) < args.limit:
+        params: dict[str, Any] = {"next_token": next_token}
+        if args.region:
+            params["region"] = args.region
+        if args.machine:
+            params["instance"] = args.machine
+        url = f"https://api.fly.io/api/v1/apps/{urllib.parse.quote(app, safe='')}/logs?{urllib.parse.urlencode(params)}"
+        payload = request_json(url, headers)
+        pages += 1
+        entries = fly_log_entries(payload)
+        if not entries:
+            complete = True
+            break
+        reached_end = False
+        for entry in entries:
+            raw_timestamp = entry.get("timestamp") or entry.get("Timestamp")
+            if not raw_timestamp:
+                continue
+            timestamp = parse_instant(str(raw_timestamp))
+            if timestamp >= end:
+                reached_end = True
+                continue
+            haystack = json.dumps(entry, sort_keys=True)
+            if pattern is None or pattern.search(haystack):
+                matches.append(entry)
+                if len(matches) >= args.limit:
+                    break
+        meta = payload.get("meta", {}) if isinstance(payload, dict) else {}
+        new_token = str(meta.get("next_token") or "")
+        if reached_end or not new_token or new_token == next_token:
+            complete = reached_end or not new_token
+            break
+        next_token = new_token
+    print_entries(matches, args.json)
+    if not complete:
+        print(
+            f"warning: incomplete buffer scan after {pages} pages or {len(matches)} matches; narrow the interval or use Grafana search",
+            file=sys.stderr,
+        )
+    print(f"matched {len(matches)} log entries across {pages} page(s)", file=sys.stderr)
+
+
+def command_metrics(args: argparse.Namespace) -> None:
+    start, end = time_window(args)
+    app = resolve_app(args.app)
+    if "$APP" not in args.query and not re.search(r"\bapp\s*=~?", args.query):
+        raise QueryError(
+            "metrics query must scope the app with an app label or the $APP placeholder"
+        )
+    query = args.query.replace("$APP", app)
+    params = {
+        "query": query,
+        "start": f"{start.timestamp():.6f}",
+        "end": f"{end.timestamp():.6f}",
+        "step": args.step,
+    }
+    if args.dry_run:
+        print(
+            json.dumps(
+                {
+                    "app": app,
+                    "start": rfc3339(start),
+                    "end": rfc3339(end),
+                    "step": args.step,
+                    "query": query,
+                    "transport": "fly" if args.org else "grafana",
+                },
+                indent=2,
+            )
+        )
+        return
+    if args.org:
+        token = read_fly_token()
+        if not token:
+            raise QueryError("Fly authentication missing; run fly auth login or set FLY_API_TOKEN")
+        url = f"https://api.fly.io/prometheus/{urllib.parse.quote(args.org, safe='')}/api/v1/query_range?{urllib.parse.urlencode(params)}"
+        payload = request_json(
+            url,
+            {"Accept": "application/json", "Authorization": authorization_value(token)},
+        )
+    else:
+        datasources = grafana_datasources(args.grafana_url)
+        datasource = choose_datasource(datasources, "metrics", args.datasource_uid)
+        uid = urllib.parse.quote(str(datasource["uid"]), safe="")
+        url = f"{args.grafana_url.rstrip('/')}/api/datasources/proxy/uid/{uid}/api/v1/query_range?{urllib.parse.urlencode(params)}"
+        payload = request_json(url, grafana_headers())
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def command_doctor(args: argparse.Namespace) -> None:
+    checks: dict[str, Any] = {
+        "fly_cli": bool(shutil.which("fly")),
+        "fly_authenticated": bool(read_fly_token()),
+        "grafana_credential_present": bool(
+            os.environ.get("FLY_GRAFANA_TOKEN") or os.environ.get("FLY_GRAFANA_COOKIE")
+        ),
+    }
+    if checks["grafana_credential_present"]:
+        try:
+            datasources = grafana_datasources(args.grafana_url)
+            checks["grafana_authenticated"] = True
+            checks["datasources"] = [
+                {
+                    "name": item.get("name"),
+                    "type": item.get("type"),
+                    "uid": item.get("uid"),
+                }
+                for item in datasources
+            ]
+        except QueryError as error:
+            checks["grafana_authenticated"] = False
+            checks["grafana_error"] = str(error)
+    print(json.dumps(checks, indent=2, sort_keys=True))
+
+
+def add_window_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--since", default="1h", help="duration or RFC3339 start (default: 1h)")
+    parser.add_argument("--until", default="now", help="RFC3339 end (default: now)")
+
+
+def add_app_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--app", default="production", help="production, staging, or exact Fly app")
+    parser.add_argument("--region")
+    parser.add_argument("--machine")
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be at least 1")
+    return parsed
+
+
+def search_limit(value: str) -> int:
+    parsed = positive_int(value)
+    if parsed > 10000:
+        raise argparse.ArgumentTypeError("value must be at most 10000")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    doctor = subparsers.add_parser("doctor", help="check read-only API access")
+    doctor.add_argument("--grafana-url", default="https://fly-metrics.net")
+    doctor.set_defaults(func=command_doctor)
+
+    search = subparsers.add_parser("search", help="server-side LogsQL search through Grafana")
+    add_app_arguments(search)
+    add_window_arguments(search)
+    search.add_argument("--query", default="*", help="LogsQL appended to the exact app filter")
+    search.add_argument("--limit", type=search_limit, default=500)
+    search.add_argument("--datasource-uid")
+    search.add_argument("--grafana-url", default="https://fly-metrics.net")
+    search.add_argument("--json", action="store_true")
+    search.add_argument("--dry-run", action="store_true")
+    search.set_defaults(func=command_search)
+
+    buffer = subparsers.add_parser("buffer", help="bounded direct Fly logs API fallback")
+    add_app_arguments(buffer)
+    add_window_arguments(buffer)
+    buffer.add_argument("--contains", help="case-insensitive Python regular expression")
+    buffer.add_argument("--limit", type=positive_int, default=500)
+    buffer.add_argument("--max-pages", type=positive_int, default=50)
+    buffer.add_argument("--json", action="store_true")
+    buffer.set_defaults(func=command_buffer)
+
+    metrics = subparsers.add_parser("metrics", help="MetricsQL range query through Grafana or Fly")
+    metrics.add_argument("--app", default="production", help="available as $APP in --query")
+    add_window_arguments(metrics)
+    metrics.add_argument("--query", required=True, help="MetricsQL/PromQL; $APP expands to the Fly app")
+    metrics.add_argument("--step", default="60s")
+    metrics.add_argument(
+        "--org",
+        default=os.environ.get("FLY_ORG"),
+        help="use Fly API for this org instead of Grafana",
+    )
+    metrics.add_argument("--datasource-uid")
+    metrics.add_argument("--grafana-url", default="https://fly-metrics.net")
+    metrics.add_argument("--dry-run", action="store_true")
+    metrics.set_defaults(func=command_metrics)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        args.func(args)
+    except (QueryError, json.JSONDecodeError, argparse.ArgumentTypeError, re.error) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a repository-local Codex skill for investigating the Fly-hosted `unpkg-files` backend without checking production credentials or raw log data into the repository. It gives future incident investigations, including follow-up work such as #478, a repeatable evidence-gathering path.

- Maps the production and staging Fly apps and routes agents through VictoriaLogs/LogsQL and Fly's Prometheus-compatible metrics API.
- Adds a read-only helper for Grafana-backed log search, bounded direct-log fallback, and time-scoped metrics queries.
- Documents authentication, retention and truncation limits, evidence standards, and explicit PII redaction rules.

Example invocation:

```text
Use $unpkg-fly-logs to identify production Machines with repeated OOM exits in the last 24 hours and inspect their pre-restart logs.
```
