### PR TITLE
Prevent tarball timeout cleanup crashes

### DIFF
--- a/packages/unpkg-files/src/lib/npm-files.ts
+++ b/packages/unpkg-files/src/lib/npm-files.ts
@@ -1,4 +1,5 @@
 import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -173,20 +174,26 @@ async function fetchAndParsePackage(
   let gunzip = gunzipMaybe();
   let extract = tar.extract();
   let settled = false;
+  let cleanedUp = false;
 
   const cleanup = () => {
-    try {
-      // Destroy all streams in the pipeline
-      tarball.destroy();
-      gunzip.destroy();
-      extract.destroy();
+    if (cleanedUp) return;
+    cleanedUp = true;
 
-      // If the response body is a ReadableStream, cancel it
-      if (response.body && typeof response.body.cancel === "function" && !response.body.locked) {
-        response.body.cancel();
+    for (let stream of [tarball, gunzip, extract]) {
+      try {
+        stream.destroy();
+      } catch (cleanupError) {
+        console.error("Error destroying tarball stream:", cleanupError);
       }
-    } catch (cleanupError) {
-      console.error("Error during cleanup:", cleanupError);
+    }
+
+    if (response.body && !response.body.locked) {
+      void response.body.cancel().catch((cleanupError) => {
+        if (!isTimeoutError(cleanupError, signal)) {
+          console.error("Error canceling tarball response body:", cleanupError);
+        }
+      });
     }
   };
 
@@ -282,7 +289,13 @@ async function fetchAndParsePackage(
       });
     });
 
-    tarball.pipe(gunzip).pipe(extract);
+    // Bun can surface a second unhandled rejection when a web response body
+    // aborts inside a manual .pipe() chain. pipeline() observes that rejection
+    // while the stream listeners above preserve the original error handling.
+    void pipeline(tarball, gunzip, extract).catch((error) => {
+      if (settled) return;
+      rejectWithCleanup(error);
+    });
   });
 }
 

--- a/packages/unpkg-files/src/lib/request-handler.test.ts
+++ b/packages/unpkg-files/src/lib/request-handler.test.ts
@@ -121,7 +121,14 @@ describe("handleRequest", () => {
 
     it("survives a timeout while consuming a tarball body", async () => {
       let timeout = AbortSignal.timeout;
-      AbortSignal.timeout = () => timeout(10);
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      AbortSignal.timeout = () => {
+        let controller = new AbortController();
+        timeoutId = setTimeout(() => {
+          controller.abort(new DOMException("The operation timed out.", "TimeoutError"));
+        }, 10);
+        return controller.signal;
+      };
 
       try {
         let response = await dispatchFetch(
@@ -133,6 +140,7 @@ describe("handleRequest", () => {
         expect(healthResponse.status).toBe(200);
         await Bun.sleep(10);
       } finally {
+        clearTimeout(timeoutId);
         AbortSignal.timeout = timeout;
       }
     });

--- a/packages/unpkg-files/src/lib/request-handler.test.ts
+++ b/packages/unpkg-files/src/lib/request-handler.test.ts
@@ -35,6 +35,23 @@ describe("handleRequest", () => {
           return new Response("Not Found", { status: 404 });
         case "https://registry.npmjs.org/timeout-package/-/timeout-package-0.0.0.tgz":
           throw new DOMException("The operation timed out.", "TimeoutError");
+        case "https://registry.npmjs.org/stalled-package/-/stalled-package-0.0.0.tgz": {
+          let signal = init?.signal;
+          return new Response(
+            new ReadableStream({
+              start(controller) {
+                // Resolve the response headers, then stall while reading a gzip body
+                // until the fetch timeout aborts it.
+                controller.enqueue(new Uint8Array([0x1f, 0x8b, 0x08, 0x00]));
+                signal?.addEventListener(
+                  "abort",
+                  () => controller.error(signal.reason),
+                  { once: true }
+                );
+              },
+            })
+          );
+        }
         default:
           throw new Error(`Unexpected URL: ${url}`);
       }
@@ -100,6 +117,24 @@ describe("handleRequest", () => {
         "https://files.unpkg.com/file/timeout-package@0.0.0/package.json"
       );
       expect(response.status).toBe(504);
+    });
+
+    it("survives a timeout while consuming a tarball body", async () => {
+      let timeout = AbortSignal.timeout;
+      AbortSignal.timeout = () => timeout(10);
+
+      try {
+        let response = await dispatchFetch(
+          "https://files.unpkg.com/file/stalled-package@0.0.0/package.json"
+        );
+        expect(response.status).toBe(504);
+
+        let healthResponse = await dispatchFetch("https://files.unpkg.com/_health");
+        expect(healthResponse.status).toBe(200);
+        await Bun.sleep(10);
+      } finally {
+        AbortSignal.timeout = timeout;
+      }
     });
 
     it("returns 404 for a missing file", async () => {


### PR DESCRIPTION
Fixes the stream cleanup race that can terminate `unpkg-files` after a tarball request has already returned `504 Gateway Timeout`. This reproduces and addresses #478 on the production Bun 1.2.8 runtime.

- observe the tar/gzip/extract pipeline promise so Bun does not surface a second unhandled timeout rejection
- make cleanup idempotent and handle response-body cancellation failures
- cover a timeout after response headers arrive while a partial gzip body is being consumed
- verify the process can handle a subsequent health request

Closes #478.
