### PR TITLE
Fix text file rendering and line navigation

### DIFF
--- a/packages/unpkg-app/src/components/code-viewer.test.ts
+++ b/packages/unpkg-app/src/components/code-viewer.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseLineHash } from "./code-viewer.tsx";
+
+describe("parseLineHash", () => {
+  it("parses single lines, ranges, and multiple selections", () => {
+    expect(parseLineHash("#L58", 100)).toEqual([58]);
+    expect(parseLineHash("#L58-59", 100)).toEqual([58, 59]);
+    expect(parseLineHash("#L2-4,8,10-11", 100)).toEqual([2, 3, 4, 8, 10, 11]);
+  });
+
+  it("deduplicates overlapping ranges", () => {
+    expect(parseLineHash("#L2-4,3-5", 100)).toEqual([2, 3, 4, 5]);
+  });
+
+  it("rejects malformed and reversed ranges", () => {
+    expect(parseLineHash("#L1foo", 100)).toEqual([]);
+    expect(parseLineHash("#L0-2", 100)).toEqual([]);
+    expect(parseLineHash("#L5-2", 100)).toEqual([]);
+    expect(parseLineHash("#L1-2,nope", 100)).toEqual([]);
+    expect(parseLineHash("#L9007199254740992", 100)).toEqual([]);
+  });
+
+  it("bounds ranges to the number of lines before expanding them", () => {
+    expect(parseLineHash("#L3-4294967295", 5)).toEqual([3, 4, 5]);
+    expect(parseLineHash("#L6-4294967295", 5)).toEqual([]);
+  });
+});

--- a/packages/unpkg-app/src/components/code-viewer.tsx
+++ b/packages/unpkg-app/src/components/code-viewer.tsx
@@ -68,21 +68,12 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
   }
 
   function handleHashChange(): void {
-    let hash = window.location.hash;
-    if (hash.startsWith("#L")) {
-      let lines = parseRanges(hash.slice(2)).reduce(
-        (lines, range) => [...lines, ...getNumbersInRange(range)],
-        [] as number[],
-      );
+    let lines = parseLineHash(window.location.hash, numLines);
+    setHighlightedLines(lines);
 
-      setHighlightedLines(lines);
-
-      let firstLine = lines[0];
-      if (firstLine != null) {
-        document.getElementById(`L${firstLine}`)?.scrollIntoView();
-      }
-    } else {
-      setHighlightedLines([]);
+    let firstLine = lines[0];
+    if (firstLine != null) {
+      document.getElementById(`L${firstLine}`)?.scrollIntoView();
     }
   }
 
@@ -92,6 +83,8 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
     return () => window.removeEventListener("hashchange", handleHashChange);
   }, []);
 
+  let highlightedLineSet = new Set(highlightedLines);
+
   return (
     <div class="flex relative bg-white font-mono text-sm leading-6">
       <div class="py-4 border-b border-x border-slate-300 bg-slate-100 text-right select-none">
@@ -100,7 +93,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
 
           return (
             <div>
-              {highlightedLines.includes(lineNumber) ? (
+              {highlightedLineSet.has(lineNumber) ? (
                 <div class="w-full h-6 bg-yellow-200 opacity-40 absolute left-0"></div>
               ) : null}
               <div class="relative">
@@ -128,16 +121,32 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
 
 type Range = [number, number];
 
-function parseRanges(rangeString: string): Range[] {
-  return rangeString.split(",").map((range) => {
-    let [start, end] = range.split("-").map((n) => parseInt(n, 10));
+export function parseLineHash(hash: string, numLines: number): number[] {
+  if (!Number.isSafeInteger(numLines) || numLines < 1 || !/^#L\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*$/.test(hash)) {
+    return [];
+  }
 
-    if (end == null) {
-      return [start, start];
+  let lineNumbers = new Set<number>();
+
+  for (let rangeString of hash.slice(2).split(",")) {
+    let [startString, endString = startString] = rangeString.split("-");
+    let start = Number(startString);
+    let end = Number(endString);
+
+    if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start < 1 || start > end) {
+      return [];
     }
 
-    return [start, end];
-  });
+    if (start > numLines) {
+      continue;
+    }
+
+    for (let lineNumber = start; lineNumber <= Math.min(end, numLines); lineNumber++) {
+      lineNumbers.add(lineNumber);
+    }
+  }
+
+  return [...lineNumbers];
 }
 
 function stringifyRanges(ranges: Range[]): string {

--- a/packages/unpkg-app/src/components/code-viewer.tsx
+++ b/packages/unpkg-app/src/components/code-viewer.tsx
@@ -76,6 +76,11 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
       );
 
       setHighlightedLines(lines);
+
+      let firstLine = lines[0];
+      if (firstLine != null) {
+        document.getElementById(`L${firstLine}`)?.scrollIntoView();
+      }
     } else {
       setHighlightedLines([]);
     }

--- a/packages/unpkg-app/src/components/file-detail.test.tsx
+++ b/packages/unpkg-app/src/components/file-detail.test.tsx
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { render } from "preact-render-to-string";
-import type { PackageFile, PackageInfo } from "unpkg-worker";
+import type { PackageFile, PackageFileMetadata, PackageInfo } from "unpkg-worker";
 
 import type { Env } from "../env.ts";
 import { HrefBuilder } from "../href-builder.ts";
 import { HrefsContext } from "../hrefs-context.ts";
 
-import { FileDetail } from "./file-detail.tsx";
+import { FileDetail, maxTextPreviewSize } from "./file-detail.tsx";
 
 const env: Env = {
   ASSETS_ORIGIN: "https://app.unpkg.com",
@@ -33,7 +33,12 @@ const packageInfo: PackageInfo = {
 
 describe("FileDetail", () => {
   it("renders all of a text file that is too large to highlight", () => {
-    let text = `${"a".repeat(50_001)}end-of-file`;
+    let lines = Array.from(
+      { length: 36_707 },
+      (_, index) => `line ${index.toString().padStart(5, "0")} ${"x".repeat(24)}`,
+    );
+    let text = lines.join("\n");
+    let lastLine = lines.at(-1) ?? "";
     let file: PackageFile = {
       body: new TextEncoder().encode(text),
       integrity: "sha256-test",
@@ -48,6 +53,90 @@ describe("FileDetail", () => {
       </HrefsContext.Provider>,
     );
 
-    expect(html).toContain("end-of-file");
+    expect(text.length).toBeLessThan(maxTextPreviewSize);
+    expect(lastLine).not.toBe("");
+    expect(html).toContain(lastLine);
+    expect(html).not.toContain("&quot;key&quot;:&quot;CodeViewer&quot;");
+    expect(html.match(/id="L\d+"/g) ?? []).toHaveLength(0);
+    expect(html.length).toBeLessThan(text.length * 2);
+  });
+
+  it("links to the raw file when a text file is too large to preview", () => {
+    let file: PackageFileMetadata = {
+      integrity: "sha256-test",
+      path: "/large.txt",
+      size: maxTextPreviewSize + 1,
+      type: "text/plain",
+    };
+
+    let html = render(
+      <HrefsContext.Provider value={new HrefBuilder(env)}>
+        <FileDetail packageInfo={packageInfo} version="1.0.0" filename="/large.txt" file={file} />
+      </HrefsContext.Provider>,
+    );
+
+    expect(html).toContain("This file is too large to preview.");
+    expect(html).toContain('href="https://unpkg.com/example@1.0.0/large.txt"');
+  });
+
+  it("renders line-heavy files as static plaintext", () => {
+    let text = Array.from({ length: 2_001 }, () => "x").join("\n");
+    let file: PackageFile = {
+      body: new TextEncoder().encode(text),
+      integrity: "sha256-test",
+      path: "/many-lines.txt",
+      size: text.length,
+      type: "text/plain",
+    };
+
+    let html = render(
+      <HrefsContext.Provider value={new HrefBuilder(env)}>
+        <FileDetail packageInfo={packageInfo} version="1.0.0" filename="/many-lines.txt" file={file} />
+      </HrefsContext.Provider>,
+    );
+
+    expect(html).not.toContain("&quot;key&quot;:&quot;CodeViewer&quot;");
+    expect(html.match(/id="L\d+"/g) ?? []).toHaveLength(0);
+  });
+
+  it("counts a newline-dense preview without interactive line elements", () => {
+    let text = "x\n".repeat(1_000_000);
+    let file: PackageFile = {
+      body: new TextEncoder().encode(text),
+      integrity: "sha256-test",
+      path: "/dense-lines.txt",
+      size: text.length,
+      type: "text/plain",
+    };
+
+    let html = render(
+      <HrefsContext.Provider value={new HrefBuilder(env)}>
+        <FileDetail packageInfo={packageInfo} version="1.0.0" filename="/dense-lines.txt" file={file} />
+      </HrefsContext.Provider>,
+    );
+
+    expect(text.length).toBeLessThan(maxTextPreviewSize);
+    expect(html).toContain("1,000,001 lines");
+    expect(html).not.toContain("&quot;key&quot;:&quot;CodeViewer&quot;");
+  });
+
+  it("does not render text whose escaped output exceeds the preview budget", () => {
+    let text = "&".repeat(maxTextPreviewSize);
+    let file: PackageFile = {
+      body: new TextEncoder().encode(text),
+      integrity: "sha256-test",
+      path: "/escaped-output.txt",
+      size: text.length,
+      type: "text/plain",
+    };
+
+    let html = render(
+      <HrefsContext.Provider value={new HrefBuilder(env)}>
+        <FileDetail packageInfo={packageInfo} version="1.0.0" filename="/escaped-output.txt" file={file} />
+      </HrefsContext.Provider>,
+    );
+
+    expect(html).toContain("This file is too large to preview.");
+    expect(html.length).toBeLessThan(100_000);
   });
 });

--- a/packages/unpkg-app/src/components/file-detail.test.tsx
+++ b/packages/unpkg-app/src/components/file-detail.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { render } from "preact-render-to-string";
+import type { PackageFile, PackageInfo } from "unpkg-worker";
+
+import type { Env } from "../env.ts";
+import { HrefBuilder } from "../href-builder.ts";
+import { HrefsContext } from "../hrefs-context.ts";
+
+import { FileDetail } from "./file-detail.tsx";
+
+const env: Env = {
+  ASSETS_ORIGIN: "https://app.unpkg.com",
+  DEV: false,
+  FILES_ORIGIN: "https://files.unpkg.com",
+  MODE: "test",
+  ORIGIN: "https://app.unpkg.com",
+  WWW_ORIGIN: "https://unpkg.com",
+};
+
+const packageInfo: PackageInfo = {
+  name: "example",
+  time: {},
+  "dist-tags": { latest: "1.0.0" },
+  versions: {
+    "1.0.0": {
+      dependencies: {},
+      description: "An example package",
+      name: "example",
+      version: "1.0.0",
+    },
+  },
+};
+
+describe("FileDetail", () => {
+  it("renders all of a text file that is too large to highlight", () => {
+    let text = `${"a".repeat(50_001)}end-of-file`;
+    let file: PackageFile = {
+      body: new TextEncoder().encode(text),
+      integrity: "sha256-test",
+      path: "/large.txt",
+      size: text.length,
+      type: "text/plain",
+    };
+
+    let html = render(
+      <HrefsContext.Provider value={new HrefBuilder(env)}>
+        <FileDetail packageInfo={packageInfo} version="1.0.0" filename="/large.txt" file={file} />
+      </HrefsContext.Provider>,
+    );
+
+    expect(html).toContain("end-of-file");
+  });
+});

--- a/packages/unpkg-app/src/components/file-detail.tsx
+++ b/packages/unpkg-app/src/components/file-detail.tsx
@@ -1,6 +1,6 @@
 import { type VNode } from "preact";
 import prettyBytes from "pretty-bytes";
-import type { PackageInfo, PackageFile } from "unpkg-worker";
+import type { PackageInfo, PackageFile, PackageFileMetadata } from "unpkg-worker";
 
 import { highlightCode } from "../highlight.ts";
 import { useHrefs } from "../hooks.ts";
@@ -16,6 +16,19 @@ import { ImageViewer } from "./image-viewer.tsx";
 // The maximum number of characters we are willing to apply syntax highlighting to.
 const maxHighlightedTextSize = 50_000;
 
+// The maximum number of interactive line links we are willing to render and hydrate.
+const maxInteractiveLineCount = 2_000;
+
+// The maximum number of bytes we are willing to load and show in a text preview.
+export const maxTextPreviewSize = 2 * 1024 * 1024;
+
+// The maximum number of escaped text bytes we are willing to include in the rendered page.
+const maxRenderedTextPreviewSize = 2 * 1024 * 1024;
+
+export function shouldLoadFileBody(file: PackageFileMetadata): boolean {
+  return !isTextFile(file) || file.size <= maxTextPreviewSize;
+}
+
 export function FileDetail({
   packageInfo,
   version,
@@ -25,30 +38,42 @@ export function FileDetail({
   packageInfo: PackageInfo;
   version: string;
   filename: string;
-  file: PackageFile;
+  file: PackageFile | PackageFileMetadata;
 }): VNode {
   let hrefs = useHrefs();
   let rawHref = hrefs.raw(packageInfo.name, version, filename);
 
-  let lines: string[] | undefined;
+  let lineCount: number | undefined;
+  let loc: number | undefined;
 
   let content: VNode;
-  if (file.type.startsWith("text/") || file.type === "application/json") {
-    let text = new TextDecoder().decode(file.body);
+  if (isTextFile(file)) {
+    if ("body" in file) {
+      let text = new TextDecoder().decode(file.body);
+      lineCount = countLines(text);
 
-    let html: string;
-    if (text.length <= maxHighlightedTextSize) {
-      html = highlightCode(text);
+      if (text.length <= maxHighlightedTextSize && lineCount <= maxInteractiveLineCount) {
+        loc = text.split("\n").filter((line) => line.trim() !== "").length;
+        content = (
+          <Hydrate>
+            <CodeViewer html={highlightCode(text)} numLines={lineCount} />
+          </Hydrate>
+        );
+      } else if (isRenderedTextWithinLimit(text)) {
+        content = (
+          <pre
+            class="py-4 px-6 border-b border-x border-slate-300 bg-white font-mono text-sm leading-6 whitespace-pre overflow-x-auto"
+            style={{ tabSize: 2 }}
+          >
+            {text}
+          </pre>
+        );
+      } else {
+        content = <LargeFileNotice rawHref={rawHref} />;
+      }
     } else {
-      html = escapeHtml(text);
+      content = <LargeFileNotice rawHref={rawHref} />;
     }
-
-    lines = text.split("\n");
-    content = (
-      <Hydrate>
-        <CodeViewer html={html} numLines={lines.length} />
-      </Hydrate>
-    );
   } else if (file.type.startsWith("image/")) {
     content = <ImageViewer alt={filename} src={rawHref} />;
   } else {
@@ -67,7 +92,7 @@ export function FileDetail({
 
       <div class="p-3 border border-slate-300 bg-slate-100 text-sm flex justify-between select-none">
         <div class="w-64">
-          {lines == null ? "" : <LineCount lines={lines} />}
+          {lineCount == null ? "" : <LineCount lineCount={lineCount} loc={loc} />}
           <span>{prettyBytes(file.size)}</span>
         </div>
         <div class="hidden flex-grow sm:block text-center">{getLanguageName(file)}</div>
@@ -83,15 +108,71 @@ export function FileDetail({
   );
 }
 
-function LineCount({ lines }: { lines: string[] }): VNode {
-  let loc = lines.filter((line) => line.trim() !== "").length;
-
+function LineCount({ lineCount, loc }: { lineCount: number; loc?: number }): VNode {
   return (
     <span>
-      <span>{formatNumber(lines.length)} lines </span>
-      {lines.length !== loc ? <span>({formatNumber(loc)} loc) </span> : null}
+      <span>{formatNumber(lineCount)} lines </span>
+      {loc != null && lineCount !== loc ? <span>({formatNumber(loc)} loc) </span> : null}
       <span>&bull; </span>
     </span>
+  );
+}
+
+function countLines(text: string): number {
+  let count = 1;
+  let index = -1;
+
+  while ((index = text.indexOf("\n", index + 1)) !== -1) {
+    count++;
+  }
+
+  return count;
+}
+
+function isRenderedTextWithinLimit(text: string): boolean {
+  let size = 0;
+
+  for (let index = 0; index < text.length; index++) {
+    let code = text.charCodeAt(index);
+
+    if (code === 38) {
+      size += 5; // &amp;
+    } else if (code === 60) {
+      size += 4; // &lt;
+    } else if (code === 34) {
+      size += 6; // &quot;
+    } else if (code <= 0x7f) {
+      size += 1;
+    } else if (code <= 0x7ff) {
+      size += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      let nextCode = text.charCodeAt(index + 1);
+      if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+        size += 4;
+        index++;
+      } else {
+        size += 3;
+      }
+    } else {
+      size += 3;
+    }
+
+    if (size > maxRenderedTextPreviewSize) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function LargeFileNotice({ rawHref }: { rawHref: string }): VNode {
+  return (
+    <div class="py-4 border-b border-x border-slate-300 bg-white text-center">
+      <span>This file is too large to preview. </span>
+      <a href={rawHref} class="text-blue-600 hover:underline">
+        View Raw
+      </a>
+    </div>
   );
 }
 
@@ -99,14 +180,6 @@ function formatNumber(num: number): string {
   return new Intl.NumberFormat("en").format(num);
 }
 
-const htmlEntities: Record<string, string> = {
-  "&": "&amp;",
-  "<": "&lt;",
-  ">": "&gt;",
-  '"': "&quot;",
-  "'": "&apos;",
-};
-
-function escapeHtml(unsafe: string) {
-  return unsafe.replace(/[&<>"']/g, (match) => htmlEntities[match]);
+function isTextFile(file: PackageFileMetadata): boolean {
+  return file.type.startsWith("text/") || file.type === "application/json";
 }

--- a/packages/unpkg-app/src/components/file-detail.tsx
+++ b/packages/unpkg-app/src/components/file-detail.tsx
@@ -13,8 +13,8 @@ import { FilesNav } from "./files-nav.tsx";
 import { Hydrate } from "./hydrate.tsx";
 import { ImageViewer } from "./image-viewer.tsx";
 
-// The maximum number of characters we are willing to show and apply highlighting.
-const maxTextSize = 50_000;
+// The maximum number of characters we are willing to apply syntax highlighting to.
+const maxHighlightedTextSize = 50_000;
 
 export function FileDetail({
   packageInfo,
@@ -37,10 +37,9 @@ export function FileDetail({
     let text = new TextDecoder().decode(file.body);
 
     let html: string;
-    if (text.length <= maxTextSize) {
+    if (text.length <= maxHighlightedTextSize) {
       html = highlightCode(text);
     } else {
-      text = text.slice(0, maxTextSize);
       html = escapeHtml(text);
     }
 

--- a/packages/unpkg-app/src/request-handler.test.ts
+++ b/packages/unpkg-app/src/request-handler.test.ts
@@ -1,6 +1,7 @@
 import { expect, describe, it, beforeAll, afterAll } from "bun:test";
 
 import { packageInfo } from "../test/fixtures.ts";
+import { maxTextPreviewSize } from "./components/file-detail.tsx";
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.tsx";
 
@@ -59,6 +60,12 @@ describe("handleRequest", () => {
               path: "/package.json",
               size: 999,
               type: "application/json",
+              integrity: "sha256-test",
+            },
+            {
+              path: "/large.txt",
+              size: maxTextPreviewSize + 1,
+              type: "text/plain",
               integrity: "sha256-test",
             },
           ],
@@ -121,6 +128,14 @@ describe("handleRequest", () => {
 
     expect(html).toContain('<html lang="en" style="background-color:white;">');
     expect(html).toContain('<body style="background-color:white;">');
+  });
+
+  it("does not fetch the body of a text file that is too large to preview", async () => {
+    let response = await dispatchFetch("https://app.unpkg.com/react@18.2.0/files/large.txt");
+    let html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(html).toContain("This file is too large to preview.");
   });
 
   it("resolves semver range on package root", async () => {

--- a/packages/unpkg-app/src/request-handler.tsx
+++ b/packages/unpkg-app/src/request-handler.tsx
@@ -5,7 +5,7 @@ import { getFile, getPackageInfo, listFiles, parsePackagePathname, resolvePackag
 import { AssetsContext } from "./assets-context.ts";
 import { loadAssetsManifest } from "./assets-manifest.ts";
 import { Document } from "./components/document.tsx";
-import { FileDetail } from "./components/file-detail.tsx";
+import { FileDetail, shouldLoadFileBody } from "./components/file-detail.tsx";
 import { FileListing } from "./components/file-listing.tsx";
 import { NotFound } from "./components/not-found.tsx";
 import type { Env } from "./env.ts";
@@ -84,11 +84,17 @@ export async function handleRequest(request: Request, env: Env, context: Executi
     let matchingFile = files.find((file) => file.path === remainingFilename);
 
     if (matchingFile != null) {
-      let file = await getFile(context, env.FILES_ORIGIN, packageName, version, remainingFilename);
+      let file = shouldLoadFileBody(matchingFile)
+        ? await getFile(context, env.FILES_ORIGIN, packageName, version, remainingFilename)
+        : matchingFile;
+
+      if (file == null) {
+        return notFound(`Not Found: ${url.pathname}`);
+      }
 
       return renderPage(
         env,
-        <FileDetail packageInfo={packageInfo} version={version} filename={remainingFilename} file={file!} />,
+        <FileDetail packageInfo={packageInfo} version={version} filename={remainingFilename} file={file} />,
         {
           headers: {
             "Cache-Control": "public, max-age=60, s-maxage=300",

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -299,6 +299,12 @@ describe("handleRequest", () => {
       expect(response.headers.get("Content-Type")).toMatch(/^text\/javascript; charset=utf-8/);
     });
 
+    it('serves non-JavaScript text files with "charset=utf-8"', async () => {
+      let response = await dispatchFetch("https://unpkg.com/react@18.2.0/LICENSE");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("text/plain; charset=utf-8");
+    });
+
     it("adds CORS headers to the response", async () => {
       let response = await dispatchFetch("https://unpkg.com/react@18.2.0/index.js");
       expect(response.status).toBe(200);

--- a/packages/unpkg-www/src/request-handler.tsx
+++ b/packages/unpkg-www/src/request-handler.tsx
@@ -236,9 +236,10 @@ export async function handleRequest(request: Request, env: Env, context: Executi
         headers.set("Cache-Control", "public, max-age=31536000");
       }
 
-      // Serve JavaScript files with charset="utf-8"
-      if (headers.get("Content-Type") === "text/javascript") {
-        headers.set("Content-Type", "text/javascript; charset=utf-8");
+      // Serve text files with charset="utf-8"
+      let contentType = headers.get("Content-Type");
+      if (contentType != null && /^text\//i.test(contentType) && !/\bcharset=/i.test(contentType)) {
+        headers.set("Content-Type", `${contentType}; charset=utf-8`);
       }
 
       // Add CORS headers

--- a/packages/unpkg-www/src/request-handler.tsx
+++ b/packages/unpkg-www/src/request-handler.tsx
@@ -14,6 +14,7 @@ import {
 import { AssetsContext } from "./assets-context.ts";
 import { loadAssetsManifest } from "./assets-manifest.ts";
 import type { Env } from "./env.ts";
+import { withUtf8Charset } from "./response.ts";
 import { Document } from "./components/document.tsx";
 import { Home } from "./components/home.tsx";
 
@@ -236,12 +237,6 @@ export async function handleRequest(request: Request, env: Env, context: Executi
         headers.set("Cache-Control", "public, max-age=31536000");
       }
 
-      // Serve text files with charset="utf-8"
-      let contentType = headers.get("Content-Type");
-      if (contentType != null && /^text\//i.test(contentType) && !/\bcharset=/i.test(contentType)) {
-        headers.set("Content-Type", `${contentType}; charset=utf-8`);
-      }
-
       // Add CORS headers
       headers.set("Access-Control-Allow-Headers", "*");
       headers.set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
@@ -251,11 +246,13 @@ export async function handleRequest(request: Request, env: Env, context: Executi
 
       let body = await response.arrayBuffer();
 
-      return new Response(body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers,
-      });
+      return withUtf8Charset(
+        new Response(body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        }),
+      );
     }
   }
 

--- a/packages/unpkg-www/src/response.ts
+++ b/packages/unpkg-www/src/response.ts
@@ -1,0 +1,10 @@
+export function withUtf8Charset(response: Response): Response {
+  let contentType = response.headers.get("Content-Type");
+  if (contentType == null || !/^text\//i.test(contentType) || /\bcharset=/i.test(contentType)) {
+    return response;
+  }
+
+  let normalizedResponse = new Response(response.body, response);
+  normalizedResponse.headers.set("Content-Type", `${contentType}; charset=utf-8`);
+  return normalizedResponse;
+}

--- a/packages/unpkg-www/src/worker.test.ts
+++ b/packages/unpkg-www/src/worker.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import type { Env } from "./env.ts";
+import worker from "./worker.ts";
+
+const context = {
+  waitUntil() {
+    throw new Error("A cache hit should not write to the cache");
+  },
+} as unknown as ExecutionContext;
+
+let originalCaches = globalThis.caches;
+
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
+
+describe("worker", () => {
+  it("adds a UTF-8 charset to cached text responses", async () => {
+    let cachedResponse = new Response('.icon::after { content: "×"; }', {
+      headers: {
+        "Cache-Control": "public, max-age=31536000",
+        "Content-Type": "text/css",
+      },
+    });
+
+    globalThis.caches = {
+      default: {
+        async match() {
+          return cachedResponse;
+        },
+      },
+    } as unknown as CacheStorage;
+
+    let response = await worker.fetch(new Request("https://unpkg.com/example@1.0.0/styles.css"), {} as Env, context);
+
+    expect(response.headers.get("Content-Type")).toBe("text/css; charset=utf-8");
+    expect(await response.text()).toContain("×");
+  });
+});

--- a/packages/unpkg-www/src/worker.ts
+++ b/packages/unpkg-www/src/worker.ts
@@ -1,22 +1,31 @@
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.tsx";
-
-// @ts-expect-error - `caches.default` is missing in @cloudflare/workers-types
-const cache = caches.default as Cache;
+import { withUtf8Charset } from "./response.ts";
 
 export default {
   async fetch(request, env, context) {
     try {
+      // @ts-expect-error - `caches.default` is missing in @cloudflare/workers-types
+      let cache = caches.default as Cache;
       let url = new URL(request.url);
       let shouldUseCache = url.pathname !== "/" && url.pathname !== "/index.html";
       let response = shouldUseCache ? await cache.match(request) : undefined;
+      let cacheMiss = response == null;
 
       if (!response) {
         response = await handleRequest(request, env, context);
+      }
 
-        if (shouldUseCache && request.method === "GET" && response.status === 200 && response.headers.has("Cache-Control")) {
-          context.waitUntil(cache.put(request, response.clone()));
-        }
+      response = withUtf8Charset(response);
+
+      if (
+        cacheMiss &&
+        shouldUseCache &&
+        request.method === "GET" &&
+        response.status === 200 &&
+        response.headers.has("Cache-Control")
+      ) {
+        context.waitUntil(cache.put(request, response.clone()));
       }
 
       if (request.method === "HEAD") {


### PR DESCRIPTION
Fixes three related problems in UNPKG's text file viewing paths so raw and app views consistently represent files and line links navigate safely.

- Normalize both fresh and cached textual responses with an explicit UTF-8 charset, allowing existing CSS cache entries to be corrected without a Cloudflare purge.
- Render small files with syntax highlighting and interactive line links, while rendering larger supported files once as bounded static plaintext. Files beyond the input or escaped-output preview budgets link directly to the raw file without fetching an unnecessary body.
- Strictly validate and bound line hashes before expanding ranges, deduplicate selections, and scroll multi-line hashes such as `#L58-59` to the first selected line.

Closes #467
Closes #465
Closes #456
