### PR TITLE
Handle null package export targets

### DIFF
--- a/packages/unpkg-esm/src/request-handler.test.ts
+++ b/packages/unpkg-esm/src/request-handler.test.ts
@@ -17,6 +17,22 @@ const context = {
   waitUntil() {},
 } as unknown as ExecutionContext;
 
+const cesiumPackageInfo = {
+  name: "cesium",
+  "dist-tags": { latest: "1.144.0" },
+  versions: {
+    "1.144.0": {
+      name: "cesium",
+      version: "1.144.0",
+      exports: {
+        ".": "./Source/Cesium.js",
+        "./Build/*": "./Build/*",
+        "./Build/*.js": null,
+      },
+    },
+  },
+};
+
 function dispatchFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   let request = input instanceof Request ? input : new Request(input, init);
   return handleRequest(request, env, context);
@@ -50,6 +66,15 @@ describe("handleRequest", () => {
       let url = new URL(request.url);
 
       if (url.origin === env.FILES_ORIGIN) {
+        if (url.pathname === "/file/cesium@1.144.0/Build/Cesium/Cesium.js") {
+          return new Response("export const Cesium = {};", {
+            headers: { "Content-Type": "application/javascript" },
+          });
+        }
+        if (url.pathname === "/build/cesium@1.144.0/Build/Cesium/Cesium.js") {
+          return new Response("Build input not found", { status: 404 });
+        }
+
         if (url.pathname === "/file/@babel/runtime@7.26.0/helpers/extends.js") {
           return new Response("export default Object.assign;\n", {
             headers: { "Content-Type": "application/javascript" },
@@ -70,6 +95,8 @@ describe("handleRequest", () => {
       }
 
       switch (url.href) {
+        case "https://registry.npmjs.org/cesium":
+          return Response.json(cesiumPackageInfo);
         case "https://registry.npmjs.org/normalize.css":
           return Response.json({
             name: "normalize.css",
@@ -295,6 +322,32 @@ describe("handleRequest", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toMatch(/^application\/json/);
     expect(await response.text()).toMatch(/"name": "react"/);
+  });
+
+  it("serves explicit raw files blocked by null package exports", async () => {
+    let redirectResponse = await dispatchFetch("https://esm.unpkg.com/cesium@1.144.0/Build/Cesium/Cesium.js?raw", {
+      redirect: "manual",
+    });
+    expect(redirectResponse.status).toBe(301);
+
+    let response = await dispatchFetch(`https://esm.unpkg.com${redirectResponse.headers.get("Location")}`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("export const Cesium = {};");
+  });
+
+  it("does not build explicit files blocked by null package exports", async () => {
+    let redirectResponse = await dispatchFetch("https://esm.unpkg.com/cesium@1.144.0/Build/Cesium/Cesium.js", {
+      redirect: "manual",
+    });
+    expect(redirectResponse.status).toBe(301);
+
+    let response = await dispatchFetch(`https://esm.unpkg.com${redirectResponse.headers.get("Location")}`);
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: "BUILD_FAILED",
+      },
+    });
   });
 
   it("redirects raw package roots to their import entry", async () => {

--- a/packages/unpkg-files/src/lib/esm-build-service.test.ts
+++ b/packages/unpkg-files/src/lib/esm-build-service.test.ts
@@ -139,6 +139,53 @@ describe("resolveBuildFilename", () => {
     expect(resolveBuildFilename(packageJson, "/dist/index.js", options())).toBe("/dist/index.js");
   });
 
+  it("does not fall back to explicit filenames blocked by null exports", () => {
+    expect(
+      resolveBuildFilename(
+        {
+          exports: {
+            "./dist/*": "./dist/*",
+            "./dist/*.js": null,
+          },
+        },
+        "/dist/index.js",
+        options()
+      )
+    ).toBe(null);
+  });
+
+  it("does not fall back to legacy entrypoints when a condition is blocked", () => {
+    expect(
+      resolveBuildFilename(
+        {
+          exports: {
+            ".": {
+              browser: null,
+              import: "./index.js",
+            },
+          },
+          main: "./legacy.js",
+        },
+        undefined,
+        options()
+      )
+    ).toBe(null);
+  });
+
+  it("does not fall back to module or main when exports is null", () => {
+    expect(
+      resolveBuildFilename(
+        {
+          exports: null,
+          main: "./legacy.js",
+          module: "./module.js",
+        },
+        undefined,
+        options()
+      )
+    ).toBe(null);
+  });
+
   it("allows extensionless browser entrypoints", () => {
     expect(
       resolveBuildFilename(

--- a/packages/unpkg-files/src/lib/esm-build-service.ts
+++ b/packages/unpkg-files/src/lib/esm-build-service.ts
@@ -6,10 +6,10 @@ import { parse as parseCommonJs } from "@esm.sh/cjs-module-lexer";
 import * as esbuild from "esbuild";
 import { parse } from "es-module-lexer/js";
 import {
-  resolvePackageExport,
+  resolvePackageExportResult,
   resolvePackageVersion,
 } from "unpkg-worker";
-import type { PackageInfo } from "unpkg-worker";
+import type { PackageInfo, PackageJson as WorkerPackageJson } from "unpkg-worker";
 
 import { getFile, withPackageFileDirectory } from "./npm-files.ts";
 
@@ -140,7 +140,7 @@ export interface InlineTransformRequest {
 
 interface PackageJson {
   dependencies?: Record<string, string>;
-  exports?: string | Record<string, unknown>;
+  exports?: string | null | Record<string, unknown>;
   main?: string;
   module?: string;
   name?: string;
@@ -496,22 +496,22 @@ export function resolveBuildFilename(
   options: Pick<NormalizedBuildOptions, "conditions" | "env" | "target">
 ): string | null {
   if (filename != null && filename !== "/") {
-    return (
-      resolvePackageExport(packageJson as Parameters<typeof resolvePackageExport>[0], filename, {
-        conditions: getBuildConditions(options),
-        useBrowserField: !isRuntimeNativeTarget(options.target),
-        useModuleField: packageJson.exports == null,
-      }) ?? filename
-    );
-  }
-
-  return (
-    resolvePackageExport(packageJson as Parameters<typeof resolvePackageExport>[0], "/", {
+    let resolution = resolvePackageExportResult(packageJson as WorkerPackageJson, filename, {
       conditions: getBuildConditions(options),
       useBrowserField: !isRuntimeNativeTarget(options.target),
-      useModuleField: packageJson.exports == null,
-    }) ?? "/index.js"
-  );
+      useModuleField: packageJson.exports === undefined,
+    });
+    if (resolution.status === "blocked") return null;
+    return resolution.status === "resolved" ? resolution.filename : filename;
+  }
+
+  let resolution = resolvePackageExportResult(packageJson as WorkerPackageJson, "/", {
+    conditions: getBuildConditions(options),
+    useBrowserField: !isRuntimeNativeTarget(options.target),
+    useModuleField: packageJson.exports === undefined,
+  });
+  if (resolution.status === "blocked") return null;
+  return resolution.status === "resolved" ? resolution.filename : "/index.js";
 }
 
 function parseConditions(searchParams: URLSearchParams): string[] {
@@ -736,7 +736,7 @@ function resolveCommonJsReexport(
   }
 
   let selfReferencePath = parsed.path === "" ? "/" : parsed.path;
-  return resolveBuildFilename(packageJson, selfReferencePath, options) ?? selfReferencePath;
+  return resolveBuildFilename(packageJson, selfReferencePath, options);
 }
 
 function readJsonExportNames(code: string): string[] {
@@ -827,7 +827,12 @@ function createPackageInternalBundlePlugin(
           let parsed = parseBareSpecifier(args.path);
           if (parsed?.packageName === packageName) {
             let selfReferencePath = parsed.path === "" ? "/" : parsed.path;
-            let resolved = resolveBuildFilename(packageJson, selfReferencePath, options) ?? selfReferencePath;
+            let resolved = resolveBuildFilename(packageJson, selfReferencePath, options);
+            if (resolved == null) {
+              return {
+                errors: [{ text: `Package subpath "${selfReferencePath}" is blocked by its exports map` }],
+              };
+            }
 
             return {
               path: resolved,

--- a/packages/unpkg-worker/src/lib/npm-info.ts
+++ b/packages/unpkg-worker/src/lib/npm-info.ts
@@ -24,7 +24,7 @@ export interface PackageJson {
   dependencies: Record<string, string>;
   description: string;
   devDependencies?: Record<string, string>;
-  exports?: string | ExportConditions;
+  exports?: ExportTarget;
   homepage?: string;
   license?: string;
   main?: string;
@@ -41,8 +41,10 @@ export interface PackageJson {
   version: string;
 }
 
+export type ExportTarget = string | null | ExportConditions;
+
 export interface ExportConditions {
-  [condition: string]: string | ExportConditions;
+  [condition: string]: ExportTarget;
 }
 
 export async function getPackageInfo(

--- a/packages/unpkg-worker/src/lib/pkg-exports.test.ts
+++ b/packages/unpkg-worker/src/lib/pkg-exports.test.ts
@@ -1,7 +1,7 @@
 import { expect, describe, it } from "bun:test";
 
 import type { PackageJson } from "./npm-info.ts";
-import { resolvePackageExport } from "./pkg-exports.ts";
+import { resolvePackageExport, resolvePackageExportResult } from "./pkg-exports.ts";
 
 describe("resolvePackageExport", () => {
   describe("when package.module is a string", () => {
@@ -218,6 +218,67 @@ describe("resolvePackageExport", () => {
 
     it("uses the matching fallback condition", () => {
       expect(resolvePackageExport(packageJson, "/vanilla", { conditions: ["default"] })).toBe("/vanilla.js");
+    });
+  });
+
+  describe("when package.exports contains null targets", () => {
+    it("blocks a top-level null export", () => {
+      let packageJson = {
+        exports: null,
+        main: "./legacy.js",
+      } as unknown as PackageJson;
+
+      expect(resolvePackageExportResult(packageJson, "/")).toEqual({ status: "blocked" });
+    });
+
+    it("blocks an exact subpath", () => {
+      let packageJson = {
+        exports: {
+          "./blocked": null,
+        },
+      } as unknown as PackageJson;
+
+      expect(resolvePackageExport(packageJson, "/blocked")).toBe(null);
+      expect(resolvePackageExportResult(packageJson, "/blocked")).toEqual({ status: "blocked" });
+    });
+
+    it("does not fall through from a specific null wildcard to a broader wildcard", () => {
+      let packageJson = {
+        exports: {
+          "./Build/*": "./Build/*",
+          "./Build/*.js": null,
+        },
+      } as unknown as PackageJson;
+
+      expect(resolvePackageExportResult(packageJson, "/Build/Cesium/Cesium.js")).toEqual({ status: "blocked" });
+    });
+
+    it("blocks a matching conditional target", () => {
+      let packageJson = {
+        exports: {
+          ".": {
+            browser: null,
+            default: "./index.js",
+          },
+        },
+        main: "./legacy.js",
+      } as unknown as PackageJson;
+
+      expect(resolvePackageExportResult(packageJson, "/", { conditions: ["browser", "default"] })).toEqual({
+        status: "blocked",
+      });
+    });
+
+    it("ignores null targets that do not match", () => {
+      let packageJson = {
+        exports: {
+          "./blocked": null,
+          "./available": "./available.js",
+        },
+      } as unknown as PackageJson;
+
+      expect(resolvePackageExport(packageJson, "/available")).toBe("/available.js");
+      expect(resolvePackageExportResult(packageJson, "/missing")).toEqual({ status: "not-found" });
     });
   });
 

--- a/packages/unpkg-worker/src/lib/pkg-exports.ts
+++ b/packages/unpkg-worker/src/lib/pkg-exports.ts
@@ -6,25 +6,43 @@ interface ResolvePackageExportOptions {
   useModuleField?: boolean;
 }
 
+export type PackageExportResolution =
+  | { status: "resolved"; filename: string }
+  | { status: "blocked" }
+  | { status: "not-found" };
+
 export function resolvePackageExport(
   packageJson: PackageJson,
   filename: string, // The filename in the request URL, e.g. "/path/to/file"
   options?: ResolvePackageExportOptions
 ): string | null {
+  let resolution = resolvePackageExportResult(packageJson, filename, options);
+  return resolution.status === "resolved" ? resolution.filename : null;
+}
+
+/**
+ * Resolves a package export while preserving the distinction between an export
+ * that is explicitly blocked by a null target and one that was not found.
+ */
+export function resolvePackageExportResult(
+  packageJson: PackageJson,
+  filename: string,
+  options?: ResolvePackageExportOptions
+): PackageExportResolution {
   // entry is either "." or "./path"
   let entry = filename === "/" ? "." : `.${filename}`;
 
   if (options?.useModuleField) {
     // "module": "./dist/index.mjs"
     if (typeof packageJson.module === "string" && entry === ".") {
-      return pathToFilename(packageJson.module);
+      return resolved(pathToFilename(packageJson.module));
     }
   }
 
   if (options?.useBrowserField) {
     // "browser": "./dist/index.js"
     if (typeof packageJson.browser === "string" && entry === ".") {
-      return pathToFilename(packageJson.browser);
+      return resolved(pathToFilename(packageJson.browser));
     }
 
     // "browser": { "./server/only.js": "./client/only.js" }
@@ -34,7 +52,7 @@ export function resolvePackageExport(
           let value = packageJson.browser[key];
 
           if (typeof value === "string") {
-            return pathToFilename(value);
+            return resolved(pathToFilename(value));
           }
         }
       }
@@ -49,29 +67,40 @@ export function resolvePackageExport(
     options?.conditions == null &&
     entry === "."
   ) {
-    return pathToFilename(packageJson.unpkg);
+    return resolved(pathToFilename(packageJson.unpkg));
+  }
+
+  if (packageJson.exports === null) {
+    return { status: "blocked" };
   }
 
   // "exports": "./dist/index.js"
   if (typeof packageJson.exports === "string" && entry === ".") {
-    return pathToFilename(packageJson.exports);
+    return resolved(pathToFilename(packageJson.exports));
   }
 
   // "exports": { ... }
   if (typeof packageJson.exports === "object" && packageJson.exports != null) {
     let conditions = options?.conditions ?? ["unpkg", "default"];
-    let resolved = resolveExportConditions(packageJson.exports, entry, conditions);
-    if (resolved != null) {
-      return pathToFilename(resolved);
+    let target = _resolveExportConditions(packageJson.exports, entry, conditions, entry === ".", null);
+    if (target === null) {
+      return { status: "blocked" };
+    }
+    if (target !== undefined) {
+      return resolved(pathToFilename(target));
     }
   }
 
   // "main": "./dist/index.js"
   if (typeof packageJson.main === "string" && entry === ".") {
-    return pathToFilename(packageJson.main);
+    return resolved(pathToFilename(packageJson.main));
   }
 
-  return null;
+  return { status: "not-found" };
+}
+
+function resolved(filename: string): PackageExportResolution {
+  return { status: "resolved", filename };
 }
 
 function pathToFilename(path: string): string {
@@ -106,7 +135,7 @@ export function resolveExportConditions(
   entry: string,
   supportedConditions: string[]
 ): string | null {
-  return _resolveExportConditions(exports, entry, supportedConditions, entry === ".", null);
+  return _resolveExportConditions(exports, entry, supportedConditions, entry === ".", null) ?? null;
 }
 
 function _resolveExportConditions(
@@ -115,11 +144,14 @@ function _resolveExportConditions(
   supportedConditions: string[],
   entryWasFound: boolean,
   wildcardMatch: string | null
-): string | null {
+): string | null | undefined {
   for (let key in exports) {
     if (!isSubpath(key) || entry !== normalizeEntryPath(key)) continue;
 
     let value = exports[key];
+    if (value === null) {
+      return null;
+    }
     if (typeof value === "string") {
       return applyWildcardMatch(value, wildcardMatch);
     }
@@ -137,12 +169,15 @@ function _resolveExportConditions(
     .sort((left, right) => wildcardSpecificity(right.key) - wildcardSpecificity(left.key));
 
   for (let { match, value } of wildcardEntries) {
+    if (value === null) {
+      return null;
+    }
     if (typeof value === "string") {
       return applyWildcardMatch(value, match);
     }
 
     let resolved = _resolveExportConditions(value, entry, supportedConditions, true, match);
-    if (resolved != null) {
+    if (resolved !== undefined) {
       return resolved;
     }
   }
@@ -151,18 +186,20 @@ function _resolveExportConditions(
     let value = exports[key];
 
     if (!isSubpath(key) && supportedConditions.includes(key)) {
-      if (typeof value === "string") {
+      if (value === null) {
+        if (entryWasFound) return null;
+      } else if (typeof value === "string") {
         if (entryWasFound) return applyWildcardMatch(value, wildcardMatch);
       } else {
         let resolved = _resolveExportConditions(value, entry, supportedConditions, entryWasFound, wildcardMatch);
-        if (resolved != null) {
+        if (resolved !== undefined) {
           return resolved;
         }
       }
     }
   }
 
-  return null;
+  return undefined;
 }
 
 function matchWildcardExport(pattern: string, entry: string): string | null {

--- a/packages/unpkg-worker/src/unpkg-worker.ts
+++ b/packages/unpkg-worker/src/unpkg-worker.ts
@@ -1,10 +1,11 @@
 export type { PackageFile, PackageFileMetadata, PackageFileListing } from "./lib/npm-files.ts";
 export { fetchFile, getFile, listFiles } from "./lib/npm-files.ts";
 
-export type { PackageInfo, PackageJson, ExportConditions } from "./lib/npm-info.ts";
+export type { PackageInfo, PackageJson, ExportConditions, ExportTarget } from "./lib/npm-info.ts";
 export { getPackageInfo } from "./lib/npm-info.ts";
 
-export { resolvePackageExport } from "./lib/pkg-exports.ts";
+export type { PackageExportResolution } from "./lib/pkg-exports.ts";
+export { resolvePackageExport, resolvePackageExportResult } from "./lib/pkg-exports.ts";
 
 export { rewriteImports } from "./lib/pkg-imports.ts";
 

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -20,6 +20,22 @@ const context = {
   waitUntil() {},
 } as unknown as ExecutionContext;
 
+const cesiumPackageInfo = {
+  name: "cesium",
+  "dist-tags": { latest: "1.144.0" },
+  versions: {
+    "1.144.0": {
+      name: "cesium",
+      version: "1.144.0",
+      exports: {
+        ".": "./Source/Cesium.js",
+        "./Build/*": "./Build/*",
+        "./Build/*.js": null,
+      },
+    },
+  },
+};
+
 function dispatchFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   let request = input instanceof Request ? input : new Request(input, init);
   return handleRequest(request, env, context);
@@ -53,12 +69,38 @@ describe("handleRequest", () => {
       let url = new URL(request.url);
 
       if (url.origin === env.FILES_ORIGIN) {
+        if (url.pathname === "/list/cesium@1.144.0/") {
+          return Response.json({
+            package: "cesium",
+            version: "1.144.0",
+            prefix: "/",
+            files: [
+              {
+                path: "/Build/Cesium/Cesium.js",
+                size: 22,
+                type: "text/javascript",
+                integrity: "sha256-dGVzdA==",
+              },
+            ],
+          });
+        }
+        if (url.pathname === "/file/cesium@1.144.0/Build/Cesium/Cesium.js") {
+          return new Response("export const Cesium = {};", {
+            headers: {
+              "Content-Digest": "sha256=:dGVzdA==:",
+              "Content-Type": "text/javascript",
+            },
+          });
+        }
+
         // Run the request through the file server. This allows us to write integration tests
         // that run without booting the file server.
         return handleFilesRequest(request);
       }
 
       switch (url.href) {
+        case "https://registry.npmjs.org/cesium":
+          return Response.json(cesiumPackageInfo);
         case "https://registry.npmjs.org/lodash":
           return fileResponse(packageInfo.lodash);
         case "https://registry.npmjs.org/preact":
@@ -199,6 +241,19 @@ describe("handleRequest", () => {
       let location = response.headers.get("Location");
       expect(location).not.toBeNull();
       expect(location).toMatch(/^\/react@\d+\.\d+\.\d+\/index\.js/);
+    });
+
+    it("serves explicit files blocked by null package exports", async () => {
+      let redirectResponse = await dispatchFetch("https://unpkg.com/cesium@latest/Build/Cesium/Cesium.js", {
+        redirect: "manual",
+      });
+      expect(redirectResponse.status).toBe(302);
+      expect(redirectResponse.headers.get("Location")).toBe("/cesium@1.144.0/Build/Cesium/Cesium.js");
+
+      let response = await dispatchFetch("https://unpkg.com/cesium@1.144.0/Build/Cesium/Cesium.js");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toMatch(/^text\/javascript/);
+      expect(await response.text()).toBe("export const Cesium = {};");
     });
 
     it("resolves npm tag and filename in a single redirect", async () => {


### PR DESCRIPTION
`null` is a valid package-exports target, but the resolver treated it as a nested conditions object and threw while resolving Cesium's more-specific wildcard. This fixes the 500 while preserving direct raw-file access. Fixes #485.

- Model `null` export targets and propagate blocked resolutions through exact, wildcard, and conditional matches.
- Distinguish blocked exports from missing exports so ESM builds do not fall back to blocked files or legacy entrypoints.
- Keep explicit raw-file requests on `unpkg.com` and `esm.unpkg.com` serving the requested file when it exists.
- Cover the Cesium URL flow plus resolver and build-service regressions.
