### PR TITLE
Add automatic dark mode and upgrade Tailwind

### DIFF
--- a/packages/unpkg-app/assets-config.ts
+++ b/packages/unpkg-app/assets-config.ts
@@ -8,7 +8,7 @@ export function getBuildOptions({ dev = false } = {}): esbuild.BuildOptions {
       "window.__DEV__": JSON.stringify(dev),
     },
     entryNames: dev ? "[dir]/[name]" : "[dir]/[name]-[hash]",
-    entryPoints: ["assets/code-light.css", "assets/scripts.ts", "assets/styles.css"],
+    entryPoints: ["assets/code-dark.css", "assets/code-light.css", "assets/scripts.ts", "assets/styles.css"],
     format: "esm",
     outbase: "assets",
     outdir: "public/_assets",

--- a/packages/unpkg-app/assets-manifest.dev.json
+++ b/packages/unpkg-app/assets-manifest.dev.json
@@ -1,4 +1,5 @@
 {
+  "assets/code-dark.css": "/code-dark.css",
   "assets/code-light.css": "/code-light.css",
   "assets/scripts.ts": "/scripts.js",
   "assets/styles.css": "/styles.css"

--- a/packages/unpkg-app/assets/code-dark.css
+++ b/packages/unpkg-app/assets/code-dark.css
@@ -1,0 +1,59 @@
+.hljs-listing {
+  background: #000;
+  color: #fff;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #858585;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-link,
+.hljs-formula {
+  color: #b98acb;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #d1787e;
+}
+.hljs-literal {
+  color: #6b9fd3;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta-string {
+  color: #8fb573;
+}
+.hljs-built_in,
+.hljs-class .hljs-title {
+  color: #c78b5e;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c8a66a;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6b9fd3;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}

--- a/packages/unpkg-app/assets/code-dark.css
+++ b/packages/unpkg-app/assets/code-dark.css
@@ -1,10 +1,10 @@
 .hljs-dark-listing {
-  background: #000;
+  background: var(--color-dark-panel);
   color: #d5ced9;
 }
 .hljs-frame,
 .hljs-frame > * {
-  border-color: #262626;
+  border-color: var(--color-dark-border);
 }
 .hljs-comment,
 .hljs-quote {

--- a/packages/unpkg-app/assets/code-dark.css
+++ b/packages/unpkg-app/assets/code-dark.css
@@ -1,38 +1,49 @@
 .hljs-listing {
   background: #000;
-  color: #fff;
+  color: #d5ced9;
 }
 .hljs-comment,
 .hljs-quote {
-  color: #858585;
+  color: #a0a1a7cc;
   font-style: italic;
 }
 .hljs-doctag,
 .hljs-keyword,
 .hljs-link,
 .hljs-formula {
-  color: #b98acb;
+  color: #c74ded;
 }
-.hljs-section,
+.hljs-section {
+  color: #ff00aa;
+}
 .hljs-name,
-.hljs-selector-tag,
-.hljs-deletion,
+.hljs-selector-tag {
+  color: #f92672;
+}
+.hljs-deletion {
+  color: #ee5d43;
+}
 .hljs-subst {
-  color: #d1787e;
+  color: #d5ced9;
 }
 .hljs-literal {
-  color: #6b9fd3;
+  color: #ee5d43;
 }
 .hljs-string,
-.hljs-regexp,
 .hljs-addition,
-.hljs-attribute,
 .hljs-meta-string {
-  color: #8fb573;
+  color: #96e072;
+}
+.hljs-regexp {
+  color: #7cb7ff;
+}
+.hljs-attribute {
+  color: #ffe66d;
 }
 .hljs-built_in,
-.hljs-class .hljs-title {
-  color: #c78b5e;
+.hljs-class .hljs-title,
+.hljs-title {
+  color: #ffe66d;
 }
 .hljs-attr,
 .hljs-variable,
@@ -40,16 +51,21 @@
 .hljs-type,
 .hljs-selector-class,
 .hljs-selector-attr,
-.hljs-selector-pseudo,
+.hljs-selector-pseudo {
+  color: #00e8c6;
+}
 .hljs-number {
-  color: #c8a66a;
+  color: #f39c12;
 }
 .hljs-symbol,
-.hljs-bullet,
-.hljs-meta,
-.hljs-selector-id,
-.hljs-title {
-  color: #6b9fd3;
+.hljs-selector-id {
+  color: #ee5d43;
+}
+.hljs-bullet {
+  color: #ffe66d;
+}
+.hljs-meta {
+  color: #c74ded;
 }
 .hljs-emphasis {
   font-style: italic;

--- a/packages/unpkg-app/assets/code-dark.css
+++ b/packages/unpkg-app/assets/code-dark.css
@@ -1,4 +1,4 @@
-.hljs-listing {
+.hljs-dark-listing {
   background: #000;
   color: #d5ced9;
 }

--- a/packages/unpkg-app/assets/code-dark.css
+++ b/packages/unpkg-app/assets/code-dark.css
@@ -1,5 +1,5 @@
 .hljs-dark-listing {
-  background: var(--color-dark-panel);
+  background: var(--color-dark-code);
   color: #d5ced9;
 }
 .hljs-frame,

--- a/packages/unpkg-app/assets/code-dark.css
+++ b/packages/unpkg-app/assets/code-dark.css
@@ -2,6 +2,10 @@
   background: #000;
   color: #d5ced9;
 }
+.hljs-frame,
+.hljs-frame > * {
+  border-color: #262626;
+}
 .hljs-comment,
 .hljs-quote {
   color: #a0a1a7cc;

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -30,4 +30,8 @@ body {
   a {
     color: #7cb7ff;
   }
+
+  body > header a {
+    color: #fff;
+  }
 }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -24,6 +24,7 @@ body {
     --color-slate-950: #fff;
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
+    --color-blue-600: #7cb7ff;
     --color-yellow-200: #404040;
   }
 
@@ -33,7 +34,6 @@ body {
   }
 
   .inline-link {
-    color: #7cb7ff;
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
   }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
 @theme {
+  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   --color-dark-page: #111;
   --color-dark-panel: #000;
   --color-dark-hover: #0a0a0a;

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -1,44 +1,28 @@
 @import "tailwindcss";
 
-:root {
-  color-scheme: light dark;
-  background: #fff;
+@theme {
+  --color-dark-page: #111;
+  --color-dark-panel: #000;
+  --color-dark-hover: #0a0a0a;
+  --color-dark-border: #262626;
+  --color-dark-muted: #a3a3a3;
+  --color-dark-secondary: #d4d4d4;
+  --color-dark-foreground: #fff;
+  --color-dark-link: #7cb7ff;
+  --color-dark-selection: #404040;
 }
 
-body {
-  background: #fff;
+:root {
+  color-scheme: light dark;
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    background: #111;
-    --color-white: #111;
-    --color-black: #fff;
-    --color-slate-50: #0a0a0a;
-    --color-slate-100: #000;
-    --color-slate-200: #262626;
-    --color-slate-300: #262626;
-    --color-slate-500: #a3a3a3;
-    --color-slate-600: #d4d4d4;
-    --color-slate-900: #fff;
-    --color-slate-950: #fff;
-    --color-gray-300: #404040;
-    --color-gray-600: #d4d4d4;
-    --color-blue-600: #7cb7ff;
-    --color-yellow-200: #404040;
-  }
-
-  body {
-    background: var(--color-white);
-    color: var(--color-slate-900);
-  }
-
   .inline-link {
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
   }
 
   .hljs-line-number:focus-visible {
-    outline: 2px solid #7cb7ff;
+    outline: 2px solid var(--color-dark-link);
   }
 }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -16,7 +16,7 @@ body {
     --color-slate-50: #0a0a0a;
     --color-slate-100: #000;
     --color-slate-200: #262626;
-    --color-slate-300: #404040;
+    --color-slate-300: #262626;
     --color-slate-500: #a3a3a3;
     --color-slate-600: #d4d4d4;
     --color-slate-900: #fff;

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -24,7 +24,6 @@ body {
     --color-slate-950: #fff;
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
-    --color-blue-600: #7cb7ff;
     --color-yellow-200: #404040;
   }
 
@@ -33,7 +32,8 @@ body {
     color: var(--color-slate-900);
   }
 
-  a.text-blue-600 {
+  .inline-link {
+    color: #7cb7ff;
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
   }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -3,12 +3,14 @@
 @theme {
   --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji";
-  --color-dark-page: #111;
-  --color-dark-panel: #000;
-  --color-dark-hover: #0a0a0a;
+  --color-dark-page: #1a1a1a;
+  --color-dark-chrome: #000;
+  --color-dark-code: #000;
+  --color-dark-panel: #222;
+  --color-dark-hover: #262626;
   --color-dark-border: #262626;
-  --color-dark-muted: #a3a3a3;
-  --color-dark-secondary: #d4d4d4;
+  --color-dark-muted: rgb(255 255 255 / 52%);
+  --color-dark-secondary: rgb(255 255 255 / 70%);
   --color-dark-foreground: #fff;
   --color-dark-link: #7cb7ff;
   --color-dark-selection: #404040;

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -2,15 +2,16 @@
 
 :root {
   color-scheme: light dark;
+  background: #fff;
 }
 
 body {
-  background: var(--color-white);
-  color: var(--color-slate-900);
+  background: #fff;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
+    background: #111;
     --color-white: #111;
     --color-black: #fff;
     --color-slate-50: #0a0a0a;
@@ -27,8 +28,17 @@ body {
     --color-yellow-200: #404040;
   }
 
+  body {
+    background: var(--color-white);
+    color: var(--color-slate-900);
+  }
+
   a.text-blue-600 {
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
+  }
+
+  .hljs-line-number:focus-visible {
+    outline: 2px solid #7cb7ff;
   }
 }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -11,10 +11,10 @@ body {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-white: #000;
+    --color-white: #111;
     --color-black: #fff;
     --color-slate-50: #0a0a0a;
-    --color-slate-100: #111;
+    --color-slate-100: #000;
     --color-slate-200: #262626;
     --color-slate-300: #404040;
     --color-slate-500: #a3a3a3;

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -24,7 +24,11 @@ body {
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
     --color-blue-600: #7cb7ff;
-    --color-yellow-200: #fde047;
+    --color-yellow-200: #404040;
   }
 
+  a.text-blue-600 {
+    text-decoration-line: underline;
+    text-underline-offset: 0.125em;
+  }
 }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -27,11 +27,4 @@ body {
     --color-yellow-200: #fde047;
   }
 
-  a {
-    color: #7cb7ff;
-  }
-
-  body > header a {
-    color: #fff;
-  }
 }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -23,7 +23,11 @@ body {
     --color-slate-950: #fff;
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
-    --color-blue-600: #60a5fa;
+    --color-blue-600: #7cb7ff;
     --color-yellow-200: #fde047;
+  }
+
+  a {
+    color: #7cb7ff;
   }
 }

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -1,1 +1,29 @@
 @import "tailwindcss";
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  background: var(--color-white);
+  color: var(--color-slate-900);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-white: #000;
+    --color-black: #fff;
+    --color-slate-50: #0a0a0a;
+    --color-slate-100: #111;
+    --color-slate-200: #262626;
+    --color-slate-300: #404040;
+    --color-slate-500: #a3a3a3;
+    --color-slate-600: #d4d4d4;
+    --color-slate-900: #fff;
+    --color-slate-950: #fff;
+    --color-gray-300: #404040;
+    --color-gray-600: #d4d4d4;
+    --color-blue-600: #60a5fa;
+    --color-yellow-200: #fde047;
+  }
+}

--- a/packages/unpkg-app/package.json
+++ b/packages/unpkg-app/package.json
@@ -13,12 +13,12 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250320.0",
-    "@ryanto/esbuild-plugin-tailwind": "^0.0.1",
+    "@ryanto/esbuild-plugin-tailwind": "^0.0.3",
     "@types/bun": "^1.2.8",
     "@types/node": "^22.10.2",
     "@types/semver": "^7.5.8",
     "esbuild": "^0.24.2",
-    "tailwindcss": "4.0.0-beta.9",
+    "tailwindcss": "4.3.3",
     "wrangler": "catalog:"
   },
   "scripts": {

--- a/packages/unpkg-app/src/components/code-viewer.test.ts
+++ b/packages/unpkg-app/src/components/code-viewer.test.ts
@@ -5,12 +5,13 @@ import { render } from "preact-render-to-string";
 import { CodeViewer, parseLineHash } from "./code-viewer.tsx";
 
 describe("CodeViewer", () => {
-  it("applies the syntax theme and a visible keyboard focus style", () => {
+  it("applies dark-only syntax and focus hooks without activating the light theme", () => {
     let html = render(h(CodeViewer, { html: '<span class="hljs-keyword">const</span> value', numLines: 1 }));
 
-    expect(html).toContain("hljs-listing");
+    expect(html).toContain("hljs-dark-listing");
     expect(html).toContain("hljs-frame");
-    expect(html).toContain("focus-visible:outline-blue-600");
+    expect(html).toContain("hljs-line-number");
+    expect(html).not.toContain('class="hljs-listing');
   });
 });
 

--- a/packages/unpkg-app/src/components/code-viewer.test.ts
+++ b/packages/unpkg-app/src/components/code-viewer.test.ts
@@ -9,6 +9,7 @@ describe("CodeViewer", () => {
     let html = render(h(CodeViewer, { html: '<span class="hljs-keyword">const</span> value', numLines: 1 }));
 
     expect(html).toContain("hljs-listing");
+    expect(html).toContain("hljs-frame");
     expect(html).toContain("focus-visible:outline-blue-600");
   });
 });

--- a/packages/unpkg-app/src/components/code-viewer.test.ts
+++ b/packages/unpkg-app/src/components/code-viewer.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "bun:test";
+import { h } from "preact";
+import { render } from "preact-render-to-string";
 
-import { parseLineHash } from "./code-viewer.tsx";
+import { CodeViewer, parseLineHash } from "./code-viewer.tsx";
+
+describe("CodeViewer", () => {
+  it("applies the syntax theme and a visible keyboard focus style", () => {
+    let html = render(h(CodeViewer, { html: '<span class="hljs-keyword">const</span> value', numLines: 1 }));
+
+    expect(html).toContain("hljs-listing");
+    expect(html).toContain("focus-visible:outline-blue-600");
+  });
+});
 
 describe("parseLineHash", () => {
   it("parses single lines, ranges, and multiple selections", () => {

--- a/packages/unpkg-app/src/components/code-viewer.tsx
+++ b/packages/unpkg-app/src/components/code-viewer.tsx
@@ -86,21 +86,21 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
   let highlightedLineSet = new Set(highlightedLines);
 
   return (
-    <div class="hljs-frame flex relative bg-white font-mono text-sm leading-6">
-      <div class="py-4 border-b border-x border-slate-300 bg-slate-100 text-right select-none">
+    <div class="hljs-frame flex relative bg-white dark:bg-dark-page font-mono text-sm leading-6">
+      <div class="py-4 border-b border-x border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-right select-none">
         {Array.from({ length: numLines }, (_, index) => {
           let lineNumber = index + 1;
 
           return (
             <div>
               {highlightedLineSet.has(lineNumber) ? (
-                <div class="w-full h-6 bg-yellow-200 opacity-40 absolute left-0"></div>
+                <div class="w-full h-6 bg-yellow-200 dark:bg-dark-selection opacity-40 absolute left-0"></div>
               ) : null}
               <div class="relative">
                 <a
                   id={`L${lineNumber}`}
                   href={`#L${lineNumber}`}
-                  class="hljs-line-number inline-block w-full pl-4 sm:pl-6 pr-2 text-slate-600 hover:text-slate-950 outline-none"
+                  class="hljs-line-number inline-block w-full pl-4 sm:pl-6 pr-2 text-slate-600 dark:text-dark-secondary hover:text-slate-950 dark:hover:text-dark-foreground outline-none"
                   onClick={handleLineLinkClick}
                 >
                   {lineNumber}
@@ -111,7 +111,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
         })}
       </div>
       <div
-        class="hljs-dark-listing py-4 pl-4 pr-6 relative border-b border-r border-slate-300 flex-grow whitespace-pre overflow-x-auto"
+        class="hljs-dark-listing py-4 pl-4 pr-6 relative border-b border-r border-slate-300 dark:border-dark-border flex-grow whitespace-pre overflow-x-auto"
         style={{ tabSize }}
         dangerouslySetInnerHTML={{ __html: html }}
       />

--- a/packages/unpkg-app/src/components/code-viewer.tsx
+++ b/packages/unpkg-app/src/components/code-viewer.tsx
@@ -87,7 +87,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
 
   return (
     <div class="hljs-frame flex relative bg-white dark:bg-dark-page font-mono text-sm leading-6">
-      <div class="py-4 border-b border-x border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-right select-none">
+      <div class="py-4 border-b border-x border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-chrome text-right select-none">
         {Array.from({ length: numLines }, (_, index) => {
           let lineNumber = index + 1;
 

--- a/packages/unpkg-app/src/components/code-viewer.tsx
+++ b/packages/unpkg-app/src/components/code-viewer.tsx
@@ -86,7 +86,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
   let highlightedLineSet = new Set(highlightedLines);
 
   return (
-    <div class="flex relative bg-white font-mono text-sm leading-6">
+    <div class="hljs-frame flex relative bg-white font-mono text-sm leading-6">
       <div class="py-4 border-b border-x border-slate-300 bg-slate-100 text-right select-none">
         {Array.from({ length: numLines }, (_, index) => {
           let lineNumber = index + 1;

--- a/packages/unpkg-app/src/components/code-viewer.tsx
+++ b/packages/unpkg-app/src/components/code-viewer.tsx
@@ -100,7 +100,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
                 <a
                   id={`L${lineNumber}`}
                   href={`#L${lineNumber}`}
-                  class="inline-block w-full pl-4 sm:pl-6 pr-2 text-slate-600 hover:text-slate-950 outline-none"
+                  class="inline-block w-full pl-4 sm:pl-6 pr-2 text-slate-600 hover:text-slate-950 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
                   onClick={handleLineLinkClick}
                 >
                   {lineNumber}
@@ -111,7 +111,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
         })}
       </div>
       <div
-        class="py-4 pl-4 pr-6 relative border-b border-r border-slate-300 flex-grow whitespace-pre overflow-x-auto"
+        class="hljs-listing py-4 pl-4 pr-6 relative border-b border-r border-slate-300 flex-grow whitespace-pre overflow-x-auto"
         style={{ tabSize }}
         dangerouslySetInnerHTML={{ __html: html }}
       />

--- a/packages/unpkg-app/src/components/code-viewer.tsx
+++ b/packages/unpkg-app/src/components/code-viewer.tsx
@@ -100,7 +100,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
                 <a
                   id={`L${lineNumber}`}
                   href={`#L${lineNumber}`}
-                  class="inline-block w-full pl-4 sm:pl-6 pr-2 text-slate-600 hover:text-slate-950 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-600"
+                  class="hljs-line-number inline-block w-full pl-4 sm:pl-6 pr-2 text-slate-600 hover:text-slate-950 outline-none"
                   onClick={handleLineLinkClick}
                 >
                   {lineNumber}
@@ -111,7 +111,7 @@ export function CodeViewer({ html, numLines }: CodeViewerProps): VNode {
         })}
       </div>
       <div
-        class="hljs-listing py-4 pl-4 pr-6 relative border-b border-r border-slate-300 flex-grow whitespace-pre overflow-x-auto"
+        class="hljs-dark-listing py-4 pl-4 pr-6 relative border-b border-r border-slate-300 flex-grow whitespace-pre overflow-x-auto"
         style={{ tabSize }}
         dangerouslySetInnerHTML={{ __html: html }}
       />

--- a/packages/unpkg-app/src/components/document.tsx
+++ b/packages/unpkg-app/src/components/document.tsx
@@ -25,7 +25,7 @@ export function Document({
   };
 
   return (
-    <html lang="en">
+    <html lang="en" class="bg-white dark:bg-dark-page">
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -54,7 +54,7 @@ gtag('config', 'UA-140352188-1');`,
           }}
         ></script>
       </head>
-      <body>{children}</body>
+      <body class="bg-white dark:bg-dark-page dark:text-dark-foreground">{children}</body>
     </html>
   );
 }

--- a/packages/unpkg-app/src/components/document.tsx
+++ b/packages/unpkg-app/src/components/document.tsx
@@ -25,15 +25,19 @@ export function Document({
   };
 
   return (
-    <html lang="en" style={{ backgroundColor: "white" }}>
+    <html lang="en">
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content={description} />
+        <meta name="color-scheme" content="light dark" />
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
 
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="stylesheet" href={useAsset("assets/styles.css")} />
         <link rel="stylesheet" href={useAsset("assets/code-light.css")} />
+        <link rel="stylesheet" href={useAsset("assets/code-dark.css")} media="(prefers-color-scheme: dark)" />
 
         <script type="importmap" dangerouslySetInnerHTML={{ __html: JSON.stringify(importMap) }} />
         <script type="module" src={useAsset("assets/scripts.ts")} defer></script>
@@ -50,7 +54,7 @@ gtag('config', 'UA-140352188-1');`,
           }}
         ></script>
       </head>
-      <body style={{ backgroundColor: "white" }}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/packages/unpkg-app/src/components/file-detail.tsx
+++ b/packages/unpkg-app/src/components/file-detail.tsx
@@ -169,7 +169,7 @@ function LargeFileNotice({ rawHref }: { rawHref: string }): VNode {
   return (
     <div class="py-4 border-b border-x border-slate-300 bg-white text-center">
       <span>This file is too large to preview. </span>
-      <a href={rawHref} class="text-blue-600 hover:underline">
+      <a href={rawHref} class="inline-link text-blue-600 hover:underline">
         View Raw
       </a>
     </div>

--- a/packages/unpkg-app/src/components/file-detail.tsx
+++ b/packages/unpkg-app/src/components/file-detail.tsx
@@ -90,7 +90,7 @@ export function FileDetail({
 
       <FilesNav packageInfo={packageInfo} version={version} filename={filename} />
 
-      <div class="p-3 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-sm flex justify-between select-none">
+      <div class="p-3 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-chrome text-sm flex justify-between select-none">
         <div class="w-64">
           {lineCount == null ? "" : <LineCount lineCount={lineCount} loc={loc} />}
           <span>{prettyBytes(file.size)}</span>

--- a/packages/unpkg-app/src/components/file-detail.tsx
+++ b/packages/unpkg-app/src/components/file-detail.tsx
@@ -62,7 +62,7 @@ export function FileDetail({
       } else if (isRenderedTextWithinLimit(text)) {
         content = (
           <pre
-            class="py-4 px-6 border-b border-x border-slate-300 bg-white font-mono text-sm leading-6 whitespace-pre overflow-x-auto"
+            class="py-4 px-6 border-b border-x border-slate-300 dark:border-dark-border bg-white dark:bg-dark-page font-mono text-sm leading-6 whitespace-pre overflow-x-auto"
             style={{ tabSize: 2 }}
           >
             {text}
@@ -78,7 +78,7 @@ export function FileDetail({
     content = <ImageViewer alt={filename} src={rawHref} />;
   } else {
     content = (
-      <div class="py-4 border-b border-x border-slate-300 bg-white text-center">
+      <div class="py-4 border-b border-x border-slate-300 dark:border-dark-border bg-white dark:bg-dark-page text-center">
         No preview is available for this file.
       </div>
     );
@@ -90,14 +90,14 @@ export function FileDetail({
 
       <FilesNav packageInfo={packageInfo} version={version} filename={filename} />
 
-      <div class="p-3 border border-slate-300 bg-slate-100 text-sm flex justify-between select-none">
+      <div class="p-3 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-sm flex justify-between select-none">
         <div class="w-64">
           {lineCount == null ? "" : <LineCount lineCount={lineCount} loc={loc} />}
           <span>{prettyBytes(file.size)}</span>
         </div>
         <div class="hidden flex-grow sm:block text-center">{getLanguageName(file)}</div>
         <div class="w-64 hidden sm:block text-right">
-          <a href={rawHref} class="py-1 px-2 border border-slate-300 bg-slate-100 hover:bg-slate-200 rounded-sm">
+          <a href={rawHref} class="py-1 px-2 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel hover:bg-slate-200 dark:hover:bg-dark-border rounded-sm">
             View Raw
           </a>
         </div>
@@ -167,9 +167,9 @@ function isRenderedTextWithinLimit(text: string): boolean {
 
 function LargeFileNotice({ rawHref }: { rawHref: string }): VNode {
   return (
-    <div class="py-4 border-b border-x border-slate-300 bg-white text-center">
+    <div class="py-4 border-b border-x border-slate-300 dark:border-dark-border bg-white dark:bg-dark-page text-center">
       <span>This file is too large to preview. </span>
-      <a href={rawHref} class="inline-link text-blue-600 hover:underline">
+      <a href={rawHref} class="inline-link text-blue-600 dark:text-dark-link hover:underline">
         View Raw
       </a>
     </div>

--- a/packages/unpkg-app/src/components/file-listing.tsx
+++ b/packages/unpkg-app/src/components/file-listing.tsx
@@ -131,7 +131,7 @@ function FileListingContent({
 
   return (
     <Fragment>
-      <header class="py-3 px-4 border border-slate-300 bg-slate-100 text-sm select-none">
+      <header class="py-3 px-4 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-sm select-none">
         {folderNames.length > 0 ? (
           <span>
             {folderNames.length} {plural("folder", folderNames.length)},{" "}
@@ -144,9 +144,9 @@ function FileListingContent({
 
       <main>
         {files.length === 0 ? (
-          <p class="p-4 border-x border-b border-slate-200 w-full bg-white">No files found.</p>
+          <p class="p-4 border-x border-b border-slate-200 dark:border-dark-border w-full bg-white dark:bg-dark-page">No files found.</p>
         ) : (
-          <table class="border-x border-b border-slate-300 w-full max-w-full bg-white">
+          <table class="border-x border-b border-slate-300 dark:border-dark-border w-full max-w-full bg-white dark:bg-dark-page">
             <thead class="hidden">
               <tr>
                 <th></th>
@@ -157,33 +157,33 @@ function FileListingContent({
             </thead>
             <tbody>
               {parentHref != null && (
-                <tr class="hover:bg-slate-50">
-                  <td class="pl-4 border-b border-slate-200 text-sm w-12">
-                    <span class="text-slate-600">
+                <tr class="hover:bg-slate-50 dark:hover:bg-dark-hover">
+                  <td class="pl-4 border-b border-slate-200 dark:border-dark-border text-sm w-12">
+                    <span class="text-slate-600 dark:text-dark-secondary">
                       <FolderIcon class="w-6 h-6" />
                     </span>
                   </td>
-                  <td colspan={3} class="pr-2 border-b border-slate-200 text-sm">
-                    <a href={parentHref} class="inline-link py-3 w-full inline-block text-blue-600 hover:underline">
+                  <td colspan={3} class="pr-2 border-b border-slate-200 dark:border-dark-border text-sm">
+                    <a href={parentHref} class="inline-link py-3 w-full inline-block text-blue-600 dark:text-dark-link hover:underline">
                       ../
                     </a>
                   </td>
                 </tr>
               )}
               {rowData.map((row) => (
-                <tr class="hover:bg-slate-50">
-                  <td class="pl-4 border-b border-slate-200 text-sm w-12">
-                    <span class="text-slate-600">{row.icon}</span>
+                <tr class="hover:bg-slate-50 dark:hover:bg-dark-hover">
+                  <td class="pl-4 border-b border-slate-200 dark:border-dark-border text-sm w-12">
+                    <span class="text-slate-600 dark:text-dark-secondary">{row.icon}</span>
                   </td>
-                  <td class="pr-2 border-b border-slate-200 text-sm max-w-60 sm:max-w-xl">
+                  <td class="pr-2 border-b border-slate-200 dark:border-dark-border text-sm max-w-60 sm:max-w-xl">
                     <div class="overflow-hidden whitespace-nowrap text-ellipsis">
-                      <a href={row.href} class="inline-link py-3 w-full inline-block text-blue-600 hover:underline">
+                      <a href={row.href} class="inline-link py-3 w-full inline-block text-blue-600 dark:text-dark-link hover:underline">
                         {row.filename}
                       </a>
                     </div>
                   </td>
-                  <td class="pr-2 border-b border-slate-200 text-sm hidden sm:table-cell">{row.contentType}</td>
-                  <td class="pr-4 border-b border-slate-200 text-sm text-right">{row.size}</td>
+                  <td class="pr-2 border-b border-slate-200 dark:border-dark-border text-sm hidden sm:table-cell">{row.contentType}</td>
+                  <td class="pr-4 border-b border-slate-200 dark:border-dark-border text-sm text-right">{row.size}</td>
                 </tr>
               ))}
             </tbody>
@@ -228,7 +228,7 @@ function FileListingSidebar({ packageInfo, version }: { packageInfo: PackageInfo
 
   return (
     <div>
-      <div class="border-b border-slate-300 pt-2 pb-1 mb-4">
+      <div class="border-b border-slate-300 dark:border-dark-border pt-2 pb-1 mb-4">
         <h2 class="text-lg font-semibold">About</h2>
       </div>
 
@@ -237,7 +237,7 @@ function FileListingSidebar({ packageInfo, version }: { packageInfo: PackageInfo
           <a
             href={websiteUrl.href}
             title={`Visit the ${packageInfo.name} website`}
-            class="inline-flex items-center hover:text-slate-950 hover:underline"
+            class="inline-flex items-center hover:text-slate-950 dark:hover:text-dark-foreground hover:underline"
           >
             <LinkIcon class="w-6 h-6" />
             <span class="ml-1">{websiteText}</span>
@@ -250,7 +250,7 @@ function FileListingSidebar({ packageInfo, version }: { packageInfo: PackageInfo
           <a
             href={githubUrl.href}
             title={`View the ${packageInfo.name} repository on GitHub`}
-            class="inline-flex items-center hover:text-slate-950 hover:underline"
+            class="inline-flex items-center hover:text-slate-950 dark:hover:text-dark-foreground hover:underline"
           >
             <GitHubIcon class="w-6 h-6" />
             <span class="ml-1">{githubText}</span>
@@ -258,7 +258,7 @@ function FileListingSidebar({ packageInfo, version }: { packageInfo: PackageInfo
         </p>
       ) : null}
 
-      <div class="border-b border-slate-300 pt-4 pb-1 mb-4">
+      <div class="border-b border-slate-300 dark:border-dark-border pt-4 pb-1 mb-4">
         <h2 class="text-lg font-semibold">Releases</h2>
       </div>
 
@@ -272,7 +272,7 @@ function FileListingSidebar({ packageInfo, version }: { packageInfo: PackageInfo
         </a>
       </p>
       <p class="text-sm">
-        <span class="text-slate-500">{formatTimeAgo(latestVersionDate)}</span>
+        <span class="text-slate-500 dark:text-dark-muted">{formatTimeAgo(latestVersionDate)}</span>
       </p>
     </div>
   );

--- a/packages/unpkg-app/src/components/file-listing.tsx
+++ b/packages/unpkg-app/src/components/file-listing.tsx
@@ -131,7 +131,7 @@ function FileListingContent({
 
   return (
     <Fragment>
-      <header class="py-3 px-4 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-sm select-none">
+      <header class="py-3 px-4 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-chrome text-sm select-none">
         {folderNames.length > 0 ? (
           <span>
             {folderNames.length} {plural("folder", folderNames.length)},{" "}

--- a/packages/unpkg-app/src/components/file-listing.tsx
+++ b/packages/unpkg-app/src/components/file-listing.tsx
@@ -164,7 +164,7 @@ function FileListingContent({
                     </span>
                   </td>
                   <td colspan={3} class="pr-2 border-b border-slate-200 text-sm">
-                    <a href={parentHref} class="py-3 w-full inline-block text-blue-600 hover:underline">
+                    <a href={parentHref} class="inline-link py-3 w-full inline-block text-blue-600 hover:underline">
                       ../
                     </a>
                   </td>
@@ -177,7 +177,7 @@ function FileListingContent({
                   </td>
                   <td class="pr-2 border-b border-slate-200 text-sm max-w-60 sm:max-w-xl">
                     <div class="overflow-hidden whitespace-nowrap text-ellipsis">
-                      <a href={row.href} class="py-3 w-full inline-block text-blue-600 hover:underline">
+                      <a href={row.href} class="inline-link py-3 w-full inline-block text-blue-600 hover:underline">
                         {row.filename}
                       </a>
                     </div>

--- a/packages/unpkg-app/src/components/files-header.tsx
+++ b/packages/unpkg-app/src/components/files-header.tsx
@@ -64,14 +64,14 @@ export function FilesHeader({
               availableVersions={availableVersions}
               currentVersion={version}
               pathnameFormat={pathnameFormat}
-              class="w-28 p-1 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-sm"
+              class="w-28 p-1 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-chrome text-sm"
             />
           </Hydrate>
         </div>
       </div>
 
       <div class="mt-2">
-        <p class="mb-3 leading-tight">
+        <p class="mb-3 leading-tight dark:text-dark-secondary">
           <span>{packageJson.description}</span>
         </p>
 

--- a/packages/unpkg-app/src/components/files-header.tsx
+++ b/packages/unpkg-app/src/components/files-header.tsx
@@ -54,7 +54,7 @@ export function FilesHeader({
   return (
     <header class="pt-6 pb-4 lg:pt-16">
       <div class="mb-6 flex justify-between items-center">
-        <h1 class="text-black text-3xl leading-tight font-semibold">{packageInfo.name}</h1>
+        <h1 class="text-black dark:text-dark-foreground text-3xl leading-tight font-semibold">{packageInfo.name}</h1>
 
         <div class="text-right w-48">
           <span>Version: </span>
@@ -64,7 +64,7 @@ export function FilesHeader({
               availableVersions={availableVersions}
               currentVersion={version}
               pathnameFormat={pathnameFormat}
-              class="w-28 p-1 border border-slate-300 bg-slate-100 text-sm"
+              class="w-28 p-1 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-sm"
             />
           </Hydrate>
         </div>
@@ -81,7 +81,7 @@ export function FilesHeader({
               <a
                 href={websiteUrl.href}
                 title={`Visit the ${packageInfo.name} website`}
-                class="inline-flex items-center hover:text-slate-950 hover:underline"
+                class="inline-flex items-center hover:text-slate-950 dark:hover:text-dark-foreground hover:underline"
               >
                 <LinkIcon class="w-6 h-6" />
                 <span class="ml-1">{websiteText}</span>
@@ -94,7 +94,7 @@ export function FilesHeader({
               <a
                 href={githubUrl.href}
                 title={`View the ${packageInfo.name} repository on GitHub`}
-                class="inline-flex items-center hover:text-slate-950 hover:underline"
+                class="inline-flex items-center hover:text-slate-950 dark:hover:text-dark-foreground hover:underline"
               >
                 <GitHubIcon class="w-6 h-6" />
                 <span class="ml-1">{githubText}</span>

--- a/packages/unpkg-app/src/components/files-layout.tsx
+++ b/packages/unpkg-app/src/components/files-layout.tsx
@@ -8,8 +8,8 @@ export function FilesLayout({ children }: { children: VNode | VNode[] }): VNode 
 
   return (
     <Fragment>
-      <header class="border-b border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-slate-950 dark:text-dark-foreground">
-        <div class="p-4 mx-auto flex justify-between items-center lg:max-w-screen-xl">
+      <header class="border-b border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-chrome text-slate-950 dark:text-dark-foreground">
+        <div class="p-4 mx-auto flex justify-between items-center lg:max-w-screen-xl lg:px-8">
           <h1 class="text-2xl font-bold inline-block">
             <a href={hrefs.home()}>UNPKG</a>
           </h1>
@@ -21,7 +21,7 @@ export function FilesLayout({ children }: { children: VNode | VNode[] }): VNode 
         </div>
       </header>
 
-      <main class="px-4 pb-24 mx-auto lg:max-w-screen-xl lg:pb-44">{children}</main>
+      <main class="px-4 pb-24 mx-auto lg:max-w-screen-xl lg:px-8 lg:pb-44">{children}</main>
     </Fragment>
   );
 }

--- a/packages/unpkg-app/src/components/files-layout.tsx
+++ b/packages/unpkg-app/src/components/files-layout.tsx
@@ -8,7 +8,7 @@ export function FilesLayout({ children }: { children: VNode | VNode[] }): VNode 
 
   return (
     <Fragment>
-      <header class="border-b border-slate-300 bg-slate-100 text-slate-950">
+      <header class="border-b border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-panel text-slate-950 dark:text-dark-foreground">
         <div class="p-4 mx-auto flex justify-between items-center lg:max-w-screen-xl">
           <h1 class="text-2xl font-bold inline-block">
             <a href={hrefs.home()}>UNPKG</a>

--- a/packages/unpkg-app/src/components/files-nav.tsx
+++ b/packages/unpkg-app/src/components/files-nav.tsx
@@ -19,7 +19,7 @@ export function FilesNav({
       <span>{packageInfo.name}</span>
     ) : (
       <span>
-        <a href={hrefs.files(packageInfo.name, version, "/")} class="text-blue-600 hover:underline">
+        <a href={hrefs.files(packageInfo.name, version, "/")} class="inline-link text-blue-600 hover:underline">
           {packageInfo.name}
         </a>
       </span>
@@ -37,7 +37,7 @@ export function FilesNav({
           let href = hrefs.files(packageInfo.name, version, "/" + parts.slice(0, index + 1).join("/"));
           acc.push(
             <span>
-              <a href={href} class="text-blue-600 hover:underline">
+              <a href={href} class="inline-link text-blue-600 hover:underline">
                 {part}
               </a>
             </span>

--- a/packages/unpkg-app/src/components/files-nav.tsx
+++ b/packages/unpkg-app/src/components/files-nav.tsx
@@ -19,7 +19,7 @@ export function FilesNav({
       <span>{packageInfo.name}</span>
     ) : (
       <span>
-        <a href={hrefs.files(packageInfo.name, version, "/")} class="inline-link text-blue-600 hover:underline">
+        <a href={hrefs.files(packageInfo.name, version, "/")} class="inline-link text-blue-600 dark:text-dark-link hover:underline">
           {packageInfo.name}
         </a>
       </span>
@@ -37,7 +37,7 @@ export function FilesNav({
           let href = hrefs.files(packageInfo.name, version, "/" + parts.slice(0, index + 1).join("/"));
           acc.push(
             <span>
-              <a href={href} class="inline-link text-blue-600 hover:underline">
+              <a href={href} class="inline-link text-blue-600 dark:text-dark-link hover:underline">
                 {part}
               </a>
             </span>

--- a/packages/unpkg-app/src/components/image-viewer.tsx
+++ b/packages/unpkg-app/src/components/image-viewer.tsx
@@ -7,7 +7,7 @@ export interface ImageViewerProps {
 
 export function ImageViewer({ alt, src }: ImageViewerProps): VNode {
   return (
-    <div class="py-8 border-b border-x border-slate-300 bg-white">
+    <div class="py-8 border-b border-x border-slate-300 dark:border-dark-border bg-white dark:bg-dark-page">
       <img alt={alt} src={src} class="w-3/4 block mx-auto" />
     </div>
   );

--- a/packages/unpkg-app/src/request-handler.test.ts
+++ b/packages/unpkg-app/src/request-handler.test.ts
@@ -129,6 +129,7 @@ describe("handleRequest", () => {
     expect(html).toContain('<meta name="color-scheme" content="light dark"/>');
     expect(html).toContain('media="(prefers-color-scheme: dark)"');
     expect(html).toContain('code-dark.css" media="(prefers-color-scheme: dark)"');
+    expect(html).toContain("inline-link");
   });
 
   it("does not fetch the body of a text file that is too large to preview", async () => {

--- a/packages/unpkg-app/src/request-handler.test.ts
+++ b/packages/unpkg-app/src/request-handler.test.ts
@@ -122,12 +122,13 @@ describe("handleRequest", () => {
     expect(location).toBe("/react@18.2.0");
   });
 
-  it("renders package pages with an explicit white background", async () => {
+  it("renders package pages that follow the preferred color scheme", async () => {
     let response = await dispatchFetch("https://app.unpkg.com/react@18.2.0");
     let html = await response.text();
 
-    expect(html).toContain('<html lang="en" style="background-color:white;">');
-    expect(html).toContain('<body style="background-color:white;">');
+    expect(html).toContain('<meta name="color-scheme" content="light dark"/>');
+    expect(html).toContain('media="(prefers-color-scheme: dark)"');
+    expect(html).toContain('code-dark.css" media="(prefers-color-scheme: dark)"');
   });
 
   it("does not fetch the body of a text file that is too large to preview", async () => {

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -316,7 +316,7 @@ footer svg {
 @media (prefers-color-scheme: dark) {
   body {
     color: #fff;
-    background: #111;
+    background: #1a1a1a;
   }
   h1 {
     color: #fff;
@@ -326,6 +326,14 @@ footer svg {
   }
   .text-blue-600 {
     color: #7cb7ff;
+  }
+  p,
+  li {
+    color: rgb(255 255 255 / 70%);
+  }
+  strong,
+  code {
+    color: #fff;
   }
   .inline-link {
     text-decoration: underline;
@@ -405,7 +413,7 @@ footer svg {
   }
   footer {
     border-color: #262626;
-    color: #d4d4d4;
+    color: rgb(255 255 255 / 70%);
   }
   footer a {
     color: #fff;

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -77,8 +77,11 @@ export function createHomePage(env: Env): string {
               <h2>Documentation</h2>
               <p>
                 For official UNPKG documentation, including package URLs, exports, metadata, import maps, and browser
-                module options, visit the <a href={`${wwwOrigin}/`}>main UNPKG home page</a>. The browser modules section
-                is available at <a href={`${wwwOrigin}/#browser-modules`}>{wwwOrigin}/#browser-modules</a>.
+                module options, visit the <a class="inline-link" href={`${wwwOrigin}/`}>main UNPKG home page</a>. The
+                browser modules section is available at{" "}
+                <a class="inline-link" href={`${wwwOrigin}/#browser-modules`}>
+                  {wwwOrigin}/#browser-modules
+                </a>.
               </p>
             </section>
           </div>
@@ -321,10 +324,8 @@ footer svg {
   h2 {
     color: #fff;
   }
-  a {
+  .inline-link {
     color: #7cb7ff;
-  }
-  main a {
     text-decoration: underline;
     text-underline-offset: 0.125em;
   }

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -324,6 +324,10 @@ footer svg {
   a {
     color: #7cb7ff;
   }
+  main a {
+    text-decoration: underline;
+    text-underline-offset: 0.125em;
+  }
   code,
   .callout {
     background: #111;

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -77,9 +77,9 @@ export function createHomePage(env: Env): string {
               <h2>Documentation</h2>
               <p>
                 For official UNPKG documentation, including package URLs, exports, metadata, import maps, and browser
-                module options, visit the <a class="inline-link" href={`${wwwOrigin}/`}>main UNPKG home page</a>. The
-                browser modules section is available at{" "}
-                <a class="inline-link" href={`${wwwOrigin}/#browser-modules`}>
+                module options, visit the <a class="inline-link text-blue-600" href={`${wwwOrigin}/`}>main UNPKG home
+                page</a>. The browser modules section is available at{" "}
+                <a class="inline-link text-blue-600" href={`${wwwOrigin}/#browser-modules`}>
                   {wwwOrigin}/#browser-modules
                 </a>.
               </p>
@@ -324,8 +324,10 @@ footer svg {
   h2 {
     color: #fff;
   }
-  .inline-link {
+  .text-blue-600 {
     color: #7cb7ff;
+  }
+  .inline-link {
     text-decoration: underline;
     text-underline-offset: 0.125em;
   }

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -91,16 +91,19 @@ export function createHomePage(env: Env): string {
 
 function Document({ children }: { children: ComponentChildren }): VNode {
   return (
-    <html lang="en" style={{ backgroundColor: "white" }}>
+    <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="description" content="Browser-ready npm package imports from UNPKG." />
+        <meta name="color-scheme" content="light dark" />
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
         <link rel="icon" type="image/png" href="/favicon.png" />
         <title>UNPKG ESM</title>
         <style dangerouslySetInnerHTML={{ __html: pageStyles }} />
       </head>
-      <body style={{ backgroundColor: "white" }}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }
@@ -306,5 +309,88 @@ footer svg {
   header { padding-top: 5rem; }
   h1 { font-size: 3.5rem; }
   main { padding-top: 3rem; }
+}
+@media (prefers-color-scheme: dark) {
+  body {
+    color: #fff;
+    background: #000;
+  }
+  h1 {
+    color: #fff;
+  }
+  h2 {
+    color: #fff;
+  }
+  a {
+    color: #60a5fa;
+  }
+  code,
+  .callout {
+    background: #111;
+  }
+  .hljs-listing {
+    background: #000;
+    color: #fff;
+  }
+  .hljs-comment,
+  .hljs-quote {
+    color: #858585;
+  }
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-link,
+  .hljs-formula {
+    color: #b98acb;
+  }
+  .hljs-section,
+  .hljs-name,
+  .hljs-selector-tag,
+  .hljs-deletion,
+  .hljs-subst {
+    color: #d1787e;
+  }
+  .hljs-literal,
+  .hljs-symbol,
+  .hljs-bullet,
+  .hljs-meta,
+  .hljs-selector-id,
+  .hljs-title {
+    color: #6b9fd3;
+  }
+  .hljs-string,
+  .hljs-regexp,
+  .hljs-addition,
+  .hljs-attribute,
+  .hljs-meta-string {
+    color: #8fb573;
+  }
+  .hljs-built_in,
+  .hljs-class .hljs-title {
+    color: #c78b5e;
+  }
+  .hljs-attr,
+  .hljs-variable,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-selector-class,
+  .hljs-selector-attr,
+  .hljs-selector-pseudo,
+  .hljs-number {
+    color: #c8a66a;
+  }
+  footer {
+    border-color: #262626;
+    color: #d4d4d4;
+  }
+  footer a {
+    color: #d4d4d4;
+  }
+  footer a:hover,
+  footer a:focus-visible {
+    color: #fff;
+  }
+  footer a:focus-visible {
+    outline-color: #a3a3a3;
+  }
 }
 `;

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -401,7 +401,7 @@ footer svg {
     color: #d4d4d4;
   }
   footer a {
-    color: #7cb7ff;
+    color: #fff;
   }
   footer a:hover,
   footer a:focus-visible {

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -313,7 +313,7 @@ footer svg {
 @media (prefers-color-scheme: dark) {
   body {
     color: #fff;
-    background: #000;
+    background: #111;
   }
   h1 {
     color: #fff;
@@ -330,7 +330,7 @@ footer svg {
   }
   code,
   .callout {
-    background: #111;
+    background: #000;
   }
   .hljs-listing {
     background: #000;

--- a/packages/unpkg-esm/src/components/home-page.tsx
+++ b/packages/unpkg-esm/src/components/home-page.tsx
@@ -322,7 +322,7 @@ footer svg {
     color: #fff;
   }
   a {
-    color: #60a5fa;
+    color: #7cb7ff;
   }
   code,
   .callout {
@@ -330,43 +330,59 @@ footer svg {
   }
   .hljs-listing {
     background: #000;
-    color: #fff;
+    color: #d5ced9;
   }
   .hljs-comment,
   .hljs-quote {
-    color: #858585;
+    color: #a0a1a7cc;
   }
   .hljs-doctag,
   .hljs-keyword,
   .hljs-link,
   .hljs-formula {
-    color: #b98acb;
+    color: #c74ded;
   }
-  .hljs-section,
+  .hljs-section {
+    color: #ff00aa;
+  }
   .hljs-name,
-  .hljs-selector-tag,
-  .hljs-deletion,
-  .hljs-subst {
-    color: #d1787e;
+  .hljs-selector-tag {
+    color: #f92672;
   }
-  .hljs-literal,
+  .hljs-deletion {
+    color: #ee5d43;
+  }
+  .hljs-subst {
+    color: #d5ced9;
+  }
+  .hljs-literal {
+    color: #ee5d43;
+  }
   .hljs-symbol,
+  .hljs-selector-id {
+    color: #ee5d43;
+  }
   .hljs-bullet,
-  .hljs-meta,
-  .hljs-selector-id,
   .hljs-title {
-    color: #6b9fd3;
+    color: #ffe66d;
+  }
+  .hljs-meta {
+    color: #c74ded;
   }
   .hljs-string,
-  .hljs-regexp,
   .hljs-addition,
-  .hljs-attribute,
   .hljs-meta-string {
-    color: #8fb573;
+    color: #96e072;
+  }
+  .hljs-regexp {
+    color: #7cb7ff;
+  }
+  .hljs-attribute {
+    color: #ffe66d;
   }
   .hljs-built_in,
   .hljs-class .hljs-title {
-    color: #c78b5e;
+    color: #ffe66d;
   }
   .hljs-attr,
   .hljs-variable,
@@ -374,16 +390,18 @@ footer svg {
   .hljs-type,
   .hljs-selector-class,
   .hljs-selector-attr,
-  .hljs-selector-pseudo,
+  .hljs-selector-pseudo {
+    color: #00e8c6;
+  }
   .hljs-number {
-    color: #c8a66a;
+    color: #f39c12;
   }
   footer {
     border-color: #262626;
     color: #d4d4d4;
   }
   footer a {
-    color: #d4d4d4;
+    color: #7cb7ff;
   }
   footer a:hover,
   footer a:focus-visible {

--- a/packages/unpkg-esm/src/request-handler.test.ts
+++ b/packages/unpkg-esm/src/request-handler.test.ts
@@ -157,7 +157,7 @@ describe("handleRequest", () => {
     expect(html).toContain("UNPKG ESM");
     expect(html).toContain("esm.unpkg.com is currently in beta.");
     expect(html).toContain("https://unpkg.com/#browser-modules");
-    expect(html).toContain('class="inline-link"');
+    expect(html).toContain('class="inline-link text-blue-600"');
     expect(html).toContain("https://esm.unpkg.com/react@18.3.1");
     expect(html).toContain('href="https://github.com/unpkg"');
     expect(html).toContain('href="https://x.com/unpkg"');

--- a/packages/unpkg-esm/src/request-handler.test.ts
+++ b/packages/unpkg-esm/src/request-handler.test.ts
@@ -151,8 +151,8 @@ describe("handleRequest", () => {
     expect(response.headers.get("Content-Type")).toMatch(/^text\/html/);
 
     let html = await response.text();
-    expect(html).toContain('<html lang="en" style="background-color:white;">');
-    expect(html).toContain('<body style="background-color:white;">');
+    expect(html).toContain('<meta name="color-scheme" content="light dark"/>');
+    expect(html).toContain("@media (prefers-color-scheme: dark)");
     expect(html).toContain('<link rel="icon" type="image/png" href="/favicon.png"/>');
     expect(html).toContain("UNPKG ESM");
     expect(html).toContain("esm.unpkg.com is currently in beta.");

--- a/packages/unpkg-esm/src/request-handler.test.ts
+++ b/packages/unpkg-esm/src/request-handler.test.ts
@@ -157,6 +157,7 @@ describe("handleRequest", () => {
     expect(html).toContain("UNPKG ESM");
     expect(html).toContain("esm.unpkg.com is currently in beta.");
     expect(html).toContain("https://unpkg.com/#browser-modules");
+    expect(html).toContain('class="inline-link"');
     expect(html).toContain("https://esm.unpkg.com/react@18.3.1");
     expect(html).toContain('href="https://github.com/unpkg"');
     expect(html).toContain('href="https://x.com/unpkg"');

--- a/packages/unpkg-www/assets-config.ts
+++ b/packages/unpkg-www/assets-config.ts
@@ -8,7 +8,7 @@ export function getBuildOptions({ dev = false } = {}): esbuild.BuildOptions {
       "window.__DEV__": JSON.stringify(dev),
     },
     entryNames: dev ? "[dir]/[name]" : "[dir]/[name]-[hash]",
-    entryPoints: ["assets/code-light.css", "assets/scripts.ts", "assets/styles.css"],
+    entryPoints: ["assets/code-dark.css", "assets/code-light.css", "assets/scripts.ts", "assets/styles.css"],
     format: "esm",
     outbase: "assets",
     outdir: "public/_assets",

--- a/packages/unpkg-www/assets-manifest.dev.json
+++ b/packages/unpkg-www/assets-manifest.dev.json
@@ -1,4 +1,5 @@
 {
+  "assets/code-dark.css": "/code-dark.css",
   "assets/code-light.css": "/code-light.css",
   "assets/scripts.ts": "/scripts.js",
   "assets/styles.css": "/styles.css"

--- a/packages/unpkg-www/assets/code-dark.css
+++ b/packages/unpkg-www/assets/code-dark.css
@@ -1,0 +1,59 @@
+.hljs-listing {
+  background: #000;
+  color: #fff;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #858585;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-link,
+.hljs-formula {
+  color: #b98acb;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #d1787e;
+}
+.hljs-literal {
+  color: #6b9fd3;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta-string {
+  color: #8fb573;
+}
+.hljs-built_in,
+.hljs-class .hljs-title {
+  color: #c78b5e;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c8a66a;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6b9fd3;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}

--- a/packages/unpkg-www/assets/code-dark.css
+++ b/packages/unpkg-www/assets/code-dark.css
@@ -1,10 +1,10 @@
 .hljs-dark-listing {
-  background: #000;
+  background: var(--color-dark-panel);
   color: #d5ced9;
 }
 .hljs-frame,
 .hljs-frame > * {
-  border-color: #262626;
+  border-color: var(--color-dark-border);
 }
 .hljs-comment,
 .hljs-quote {

--- a/packages/unpkg-www/assets/code-dark.css
+++ b/packages/unpkg-www/assets/code-dark.css
@@ -1,38 +1,49 @@
 .hljs-listing {
   background: #000;
-  color: #fff;
+  color: #d5ced9;
 }
 .hljs-comment,
 .hljs-quote {
-  color: #858585;
+  color: #a0a1a7cc;
   font-style: italic;
 }
 .hljs-doctag,
 .hljs-keyword,
 .hljs-link,
 .hljs-formula {
-  color: #b98acb;
+  color: #c74ded;
 }
-.hljs-section,
+.hljs-section {
+  color: #ff00aa;
+}
 .hljs-name,
-.hljs-selector-tag,
-.hljs-deletion,
+.hljs-selector-tag {
+  color: #f92672;
+}
+.hljs-deletion {
+  color: #ee5d43;
+}
 .hljs-subst {
-  color: #d1787e;
+  color: #d5ced9;
 }
 .hljs-literal {
-  color: #6b9fd3;
+  color: #ee5d43;
 }
 .hljs-string,
-.hljs-regexp,
 .hljs-addition,
-.hljs-attribute,
 .hljs-meta-string {
-  color: #8fb573;
+  color: #96e072;
+}
+.hljs-regexp {
+  color: #7cb7ff;
+}
+.hljs-attribute {
+  color: #ffe66d;
 }
 .hljs-built_in,
-.hljs-class .hljs-title {
-  color: #c78b5e;
+.hljs-class .hljs-title,
+.hljs-title {
+  color: #ffe66d;
 }
 .hljs-attr,
 .hljs-variable,
@@ -40,16 +51,21 @@
 .hljs-type,
 .hljs-selector-class,
 .hljs-selector-attr,
-.hljs-selector-pseudo,
+.hljs-selector-pseudo {
+  color: #00e8c6;
+}
 .hljs-number {
-  color: #c8a66a;
+  color: #f39c12;
 }
 .hljs-symbol,
-.hljs-bullet,
-.hljs-meta,
-.hljs-selector-id,
-.hljs-title {
-  color: #6b9fd3;
+.hljs-selector-id {
+  color: #ee5d43;
+}
+.hljs-bullet {
+  color: #ffe66d;
+}
+.hljs-meta {
+  color: #c74ded;
 }
 .hljs-emphasis {
   font-style: italic;

--- a/packages/unpkg-www/assets/code-dark.css
+++ b/packages/unpkg-www/assets/code-dark.css
@@ -1,4 +1,4 @@
-.hljs-listing {
+.hljs-dark-listing {
   background: #000;
   color: #d5ced9;
 }

--- a/packages/unpkg-www/assets/code-dark.css
+++ b/packages/unpkg-www/assets/code-dark.css
@@ -1,5 +1,5 @@
 .hljs-dark-listing {
-  background: var(--color-dark-panel);
+  background: var(--color-dark-code);
   color: #d5ced9;
 }
 .hljs-frame,

--- a/packages/unpkg-www/assets/code-dark.css
+++ b/packages/unpkg-www/assets/code-dark.css
@@ -2,6 +2,10 @@
   background: #000;
   color: #d5ced9;
 }
+.hljs-frame,
+.hljs-frame > * {
+  border-color: #262626;
+}
 .hljs-comment,
 .hljs-quote {
   color: #a0a1a7cc;

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -1,12 +1,18 @@
 @import "tailwindcss";
 
-:root {
-  color-scheme: light dark;
-  background: #fff;
+@theme {
+  --color-dark-page: #111;
+  --color-dark-panel: #000;
+  --color-dark-border: #262626;
+  --color-dark-border-strong: #404040;
+  --color-dark-muted: #a3a3a3;
+  --color-dark-secondary: #d4d4d4;
+  --color-dark-foreground: #fff;
+  --color-dark-link: #7cb7ff;
 }
 
-body {
-  background: #fff;
+:root {
+  color-scheme: light dark;
 }
 
 html {
@@ -24,40 +30,13 @@ section[id] {
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    background: #111;
-    --color-white: #111;
-    --color-black: #fff;
-    --color-slate-50: #0a0a0a;
-    --color-slate-100: #000;
-    --color-slate-200: #262626;
-    --color-slate-300: #404040;
-    --color-slate-500: #a3a3a3;
-    --color-slate-600: #d4d4d4;
-    --color-slate-900: #fff;
-    --color-slate-950: #fff;
-    --color-gray-300: #404040;
-    --color-gray-600: #d4d4d4;
-    --color-blue-600: #7cb7ff;
-    --color-yellow-200: #404040;
-  }
-
-  body {
-    background: var(--color-white);
-    color: var(--color-slate-900);
-  }
-
   .inline-link {
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
   }
 
-  footer a {
-    color: #fff;
-  }
-
   .section-permalink:focus-visible::after {
-    color: #7cb7ff;
+    color: var(--color-dark-link);
     opacity: 1;
   }
 }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -38,7 +38,6 @@ section[id] {
     --color-slate-950: #fff;
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
-    --color-blue-600: #7cb7ff;
     --color-yellow-200: #404040;
   }
 
@@ -47,7 +46,8 @@ section[id] {
     color: var(--color-slate-900);
   }
 
-  a.text-blue-600 {
+  .inline-link {
+    color: #7cb7ff;
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
   }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -25,10 +25,10 @@ section[id] {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-white: #000;
+    --color-white: #111;
     --color-black: #fff;
     --color-slate-50: #0a0a0a;
-    --color-slate-100: #111;
+    --color-slate-100: #000;
     --color-slate-200: #262626;
     --color-slate-300: #404040;
     --color-slate-500: #a3a3a3;

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -37,7 +37,11 @@ section[id] {
     --color-slate-950: #fff;
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
-    --color-blue-600: #60a5fa;
+    --color-blue-600: #7cb7ff;
     --color-yellow-200: #fde047;
+  }
+
+  a {
+    color: #7cb7ff;
   }
 }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
 @theme {
+  --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    "Noto Color Emoji";
   --color-dark-page: #111;
   --color-dark-panel: #000;
   --color-dark-border: #262626;

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -38,6 +38,7 @@ section[id] {
     --color-slate-950: #fff;
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
+    --color-blue-600: #7cb7ff;
     --color-yellow-200: #404040;
   }
 
@@ -47,7 +48,6 @@ section[id] {
   }
 
   .inline-link {
-    color: #7cb7ff;
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
   }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -2,11 +2,11 @@
 
 :root {
   color-scheme: light dark;
+  background: #fff;
 }
 
 body {
-  background: var(--color-white);
-  color: var(--color-slate-900);
+  background: #fff;
 }
 
 html {
@@ -25,6 +25,7 @@ section[id] {
 
 @media (prefers-color-scheme: dark) {
   :root {
+    background: #111;
     --color-white: #111;
     --color-black: #fff;
     --color-slate-50: #0a0a0a;
@@ -41,6 +42,11 @@ section[id] {
     --color-yellow-200: #404040;
   }
 
+  body {
+    background: var(--color-white);
+    color: var(--color-slate-900);
+  }
+
   a.text-blue-600 {
     text-decoration-line: underline;
     text-underline-offset: 0.125em;
@@ -48,5 +54,10 @@ section[id] {
 
   footer a {
     color: #fff;
+  }
+
+  .section-permalink:focus-visible::after {
+    color: #7cb7ff;
+    opacity: 1;
   }
 }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -1,5 +1,14 @@
 @import "tailwindcss";
 
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  background: var(--color-white);
+  color: var(--color-slate-900);
+}
+
 html {
   scroll-behavior: smooth;
 }
@@ -11,5 +20,24 @@ section[id] {
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-white: #000;
+    --color-black: #fff;
+    --color-slate-50: #0a0a0a;
+    --color-slate-100: #111;
+    --color-slate-200: #262626;
+    --color-slate-300: #404040;
+    --color-slate-500: #a3a3a3;
+    --color-slate-600: #d4d4d4;
+    --color-slate-900: #fff;
+    --color-slate-950: #fff;
+    --color-gray-300: #404040;
+    --color-gray-600: #d4d4d4;
+    --color-blue-600: #60a5fa;
+    --color-yellow-200: #fde047;
   }
 }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -3,12 +3,13 @@
 @theme {
   --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji";
-  --color-dark-page: #111;
-  --color-dark-panel: #000;
+  --color-dark-page: #1a1a1a;
+  --color-dark-code: #000;
+  --color-dark-panel: #222;
   --color-dark-border: #262626;
   --color-dark-border-strong: #404040;
-  --color-dark-muted: #a3a3a3;
-  --color-dark-secondary: #d4d4d4;
+  --color-dark-muted: rgb(255 255 255 / 52%);
+  --color-dark-secondary: rgb(255 255 255 / 70%);
   --color-dark-foreground: #fff;
   --color-dark-link: #7cb7ff;
 }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -41,7 +41,7 @@ section[id] {
     --color-yellow-200: #fde047;
   }
 
-  a {
-    color: #7cb7ff;
+  footer a {
+    color: #fff;
   }
 }

--- a/packages/unpkg-www/assets/styles.css
+++ b/packages/unpkg-www/assets/styles.css
@@ -38,7 +38,12 @@ section[id] {
     --color-gray-300: #404040;
     --color-gray-600: #d4d4d4;
     --color-blue-600: #7cb7ff;
-    --color-yellow-200: #fde047;
+    --color-yellow-200: #404040;
+  }
+
+  a.text-blue-600 {
+    text-decoration-line: underline;
+    text-underline-offset: 0.125em;
   }
 
   footer a {

--- a/packages/unpkg-www/package.json
+++ b/packages/unpkg-www/package.json
@@ -11,11 +11,11 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250320.0",
-    "@ryanto/esbuild-plugin-tailwind": "^0.0.1",
+    "@ryanto/esbuild-plugin-tailwind": "^0.0.3",
     "@types/bun": "^1.2.8",
     "@types/node": "^22.10.2",
     "esbuild": "^0.24.2",
-    "tailwindcss": "4.0.0-beta.9",
+    "tailwindcss": "4.3.3",
     "unpkg-files": "workspace:*",
     "wrangler": "catalog:"
   },

--- a/packages/unpkg-www/src/components/code-block.tsx
+++ b/packages/unpkg-www/src/components/code-block.tsx
@@ -11,7 +11,7 @@ export function CodeBlock({ children }: { children: string }): VNode {
 
   return (
     <div
-      class="p-4 font-mono text-sm leading-6 bg-white border border-slate-300 whitespace-pre overflow-x-auto"
+      class="hljs-listing p-4 font-mono text-sm leading-6 bg-white border border-slate-300 whitespace-pre overflow-x-auto"
       style={{ tabSize }}
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/packages/unpkg-www/src/components/code-block.tsx
+++ b/packages/unpkg-www/src/components/code-block.tsx
@@ -11,7 +11,7 @@ export function CodeBlock({ children }: { children: string }): VNode {
 
   return (
     <div
-      class="hljs-listing p-4 font-mono text-sm leading-6 bg-white border border-slate-300 whitespace-pre overflow-x-auto"
+      class="hljs-frame hljs-listing p-4 font-mono text-sm leading-6 bg-white border border-slate-300 whitespace-pre overflow-x-auto"
       style={{ tabSize }}
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/packages/unpkg-www/src/components/code-block.tsx
+++ b/packages/unpkg-www/src/components/code-block.tsx
@@ -11,7 +11,7 @@ export function CodeBlock({ children }: { children: string }): VNode {
 
   return (
     <div
-      class="hljs-frame hljs-dark-listing p-4 font-mono text-sm leading-6 bg-white border border-slate-300 whitespace-pre overflow-x-auto"
+      class="hljs-frame hljs-dark-listing p-4 font-mono text-sm leading-6 bg-white dark:bg-dark-page border border-slate-300 dark:border-dark-border-strong whitespace-pre overflow-x-auto"
       style={{ tabSize }}
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/packages/unpkg-www/src/components/code-block.tsx
+++ b/packages/unpkg-www/src/components/code-block.tsx
@@ -11,7 +11,7 @@ export function CodeBlock({ children }: { children: string }): VNode {
 
   return (
     <div
-      class="hljs-frame hljs-listing p-4 font-mono text-sm leading-6 bg-white border border-slate-300 whitespace-pre overflow-x-auto"
+      class="hljs-frame hljs-dark-listing p-4 font-mono text-sm leading-6 bg-white border border-slate-300 whitespace-pre overflow-x-auto"
       style={{ tabSize }}
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/packages/unpkg-www/src/components/document.tsx
+++ b/packages/unpkg-www/src/components/document.tsx
@@ -23,7 +23,7 @@ export function Document({
   };
 
   return (
-    <html lang="en">
+    <html lang="en" class="bg-white dark:bg-dark-page">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -52,7 +52,7 @@ gtag('config', 'UA-140352188-1');`,
           }}
         ></script>
       </head>
-      <body>{children}</body>
+      <body class="bg-white dark:bg-dark-page dark:text-dark-foreground">{children}</body>
     </html>
   );
 }

--- a/packages/unpkg-www/src/components/document.tsx
+++ b/packages/unpkg-www/src/components/document.tsx
@@ -23,15 +23,19 @@ export function Document({
   };
 
   return (
-    <html lang="en" style={{ backgroundColor: "white" }}>
+    <html lang="en">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="description" content={description} />
+        <meta name="color-scheme" content="light dark" />
+        <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+        <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
 
         <link rel="icon" type="image/png" href="/favicon.png" />
         <link rel="stylesheet" href={useAsset("assets/styles.css")} />
         <link rel="stylesheet" href={useAsset("assets/code-light.css")} />
+        <link rel="stylesheet" href={useAsset("assets/code-dark.css")} media="(prefers-color-scheme: dark)" />
 
         <script type="importmap" dangerouslySetInnerHTML={{ __html: JSON.stringify(importMap) }} />
         <script type="module" src={useAsset("assets/scripts.ts")} defer></script>
@@ -48,7 +52,7 @@ gtag('config', 'UA-140352188-1');`,
           }}
         ></script>
       </head>
-      <body style={{ backgroundColor: "white" }}>{children}</body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/packages/unpkg-www/src/components/home-nav.tsx
+++ b/packages/unpkg-www/src/components/home-nav.tsx
@@ -48,11 +48,11 @@ export function HomeNav({ items }: { items: Record<string, string> }): VNode {
   }
 
   return (
-    <nav class="relative border-l-1 border-gray-300 text-slate-600">
-      <div class="absolute w-1 h-6.5 transition-all duration-300 bg-gray-600" style={{ top: markerTop }} />
+    <nav class="relative border-l-1 border-gray-300 dark:border-dark-border-strong text-slate-600 dark:text-dark-secondary">
+      <div class="absolute w-1 h-6.5 transition-all duration-300 bg-gray-600 dark:bg-dark-secondary" style={{ top: markerTop }} />
       <ol>
         {Object.entries(items).map(([id, title]) => (
-          <li id={`${id}-nav-item`} class={id === currentSectionId ? "my-2 pl-8 text-slate-900" : "my-2 pl-8"}>
+          <li id={`${id}-nav-item`} class={id === currentSectionId ? "my-2 pl-8 text-slate-900 dark:text-dark-foreground" : "my-2 pl-8"}>
             <a href={`#${id}`}>{title}</a>
           </li>
         ))}

--- a/packages/unpkg-www/src/components/home-nav.tsx
+++ b/packages/unpkg-www/src/components/home-nav.tsx
@@ -48,7 +48,7 @@ export function HomeNav({ items }: { items: Record<string, string> }): VNode {
   }
 
   return (
-    <nav class="relative border-l-1 border-gray-300 dark:border-dark-border-strong text-slate-600 dark:text-dark-secondary">
+    <nav class="relative border-l-1 border-gray-300 dark:border-dark-border-strong text-base text-slate-600 dark:text-dark-secondary">
       <div class="absolute w-1 h-6.5 transition-all duration-300 bg-gray-600 dark:bg-dark-secondary" style={{ top: markerTop }} />
       <ol>
         {Object.entries(items).map(([id, title]) => (

--- a/packages/unpkg-www/src/components/home.tsx
+++ b/packages/unpkg-www/src/components/home.tsx
@@ -932,7 +932,7 @@ function SectionHeading({ id, children }: { id: string; children: string }): VNo
     <h2 class="mt-16 mb-8 text-lg font-semibold group">
       {children}{" "}
       <a
-        class="outline-none after:content-['#'] after:ml-1 after:text-slate-300 after:opacity-0 group-hover:after:opacity-100 focus-visible:after:opacity-100 focus-visible:after:text-blue-600 after:transition-opacity"
+        class="section-permalink outline-none after:content-['#'] after:ml-1 after:text-slate-300 after:opacity-0 group-hover:after:opacity-100 after:transition-opacity"
         href={`#${id}`}
       />
     </h2>

--- a/packages/unpkg-www/src/components/home.tsx
+++ b/packages/unpkg-www/src/components/home.tsx
@@ -29,7 +29,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
             <section id="overview">
               <p>
                 UNPKG is a fast, global content delivery network for everything on{" "}
-                <a class="text-blue-600 hover:underline" href="https://www.npmjs.com/">
+                <a class="inline-link text-blue-600 hover:underline" href="https://www.npmjs.com/">
                   npm
                 </a>
                 . Use it to quickly and easily load any file on npm using a URL like:
@@ -77,17 +77,17 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline break-all" href="/preact@10.26.4/dist/preact.min.js">
+                  <a class="inline-link text-blue-600 hover:underline break-all" href="/preact@10.26.4/dist/preact.min.js">
                     unpkg.com/preact@10.26.4/dist/preact.min.js
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline break-all" href="/react@18.3.1/umd/react.production.min.js">
+                  <a class="inline-link text-blue-600 hover:underline break-all" href="/react@18.3.1/umd/react.production.min.js">
                     unpkg.com/react@18.3.1/umd/react.production.min.js
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline break-all" href="/three@0.174.0/build/three.module.min.js">
+                  <a class="inline-link text-blue-600 hover:underline break-all" href="/three@0.174.0/build/three.module.min.js">
                     unpkg.com/three@0.174.0/build/three.module.min.js
                   </a>
                 </li>
@@ -95,11 +95,11 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 You can also use any valid{" "}
-                <a class="text-blue-600 hover:underline" href="https://docs.npmjs.com/about-semantic-versioning">
+                <a class="inline-link text-blue-600 hover:underline" href="https://docs.npmjs.com/about-semantic-versioning">
                   semver
                 </a>{" "}
                 range or{" "}
-                <a class="text-blue-600 hover:underline" href="https://docs.npmjs.com/adding-dist-tags-to-packages">
+                <a class="inline-link text-blue-600 hover:underline" href="https://docs.npmjs.com/adding-dist-tags-to-packages">
                   npm tag
                 </a>
                 :
@@ -107,12 +107,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline break-all" href="/preact@latest/dist/preact.min.js">
+                  <a class="inline-link text-blue-600 hover:underline break-all" href="/preact@latest/dist/preact.min.js">
                     unpkg.com/preact@latest/dist/preact.min.js
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline break-all" href="/react@^18/umd/react.production.min.js">
+                  <a class="inline-link text-blue-600 hover:underline break-all" href="/react@^18/umd/react.production.min.js">
                     unpkg.com/react@^18/umd/react.production.min.js
                   </a>
                 </li>
@@ -125,12 +125,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li>
-                  <a class="text-blue-600 hover:underline break-all" href="/preact/dist/preact.min.js">
+                  <a class="inline-link text-blue-600 hover:underline break-all" href="/preact/dist/preact.min.js">
                     unpkg.com/preact/dist/preact.min.js
                   </a>
                 </li>
                 <li>
-                  <a class="text-blue-600 hover:underline break-all" href="/vue/dist/vue.esm-browser.prod.js">
+                  <a class="inline-link text-blue-600 hover:underline break-all" href="/vue/dist/vue.esm-browser.prod.js">
                     unpkg.com/vue/dist/vue.esm-browser.prod.js
                   </a>
                 </li>
@@ -143,17 +143,17 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline" href="/react/">
+                  <a class="inline-link text-blue-600 hover:underline" href="/react/">
                     unpkg.com/react/
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline" href="/preact/src/">
+                  <a class="inline-link text-blue-600 hover:underline" href="/preact/src/">
                     unpkg.com/preact/src/
                   </a>
                 </li>
                 <li>
-                  <a class="text-blue-600 hover:underline" href="/react-router/">
+                  <a class="inline-link text-blue-600 hover:underline" href="/react-router/">
                     unpkg.com/react-router/
                   </a>
                 </li>
@@ -165,12 +165,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline" href="/react@18/">
+                  <a class="inline-link text-blue-600 hover:underline" href="/react@18/">
                     unpkg.com/react@18/
                   </a>
                 </li>
                 <li>
-                  <a class="text-blue-600 hover:underline" href="/react-router@5/">
+                  <a class="inline-link text-blue-600 hover:underline" href="/react-router@5/">
                     unpkg.com/react-router@5/
                   </a>
                 </li>
@@ -179,14 +179,14 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               <p class="mt-4">
                 If you don't specify a file path, UNPKG will resolve the file based on the package's default{" "}
                 <a
-                  class="text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 hover:underline"
                   href="https://nodejs.org/api/packages.html#package-entry-points"
                 >
                   entry point
                 </a>
                 . In many packages that are meant solely for frontend development, like jQuery and GSAP, this will be
                 the value of{" "}
-                <a class="text-blue-600 hover:underline" href="https://nodejs.org/api/packages.html#main">
+                <a class="inline-link text-blue-600 hover:underline" href="https://nodejs.org/api/packages.html#main">
                   the <code class="text-sm bg-slate-100">main</code> field
                 </a>{" "}
                 in the <code class="text-sm bg-slate-100">package.json</code> file.
@@ -194,12 +194,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline" href="/jquery">
+                  <a class="inline-link text-blue-600 hover:underline" href="/jquery">
                     unpkg.com/jquery
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="text-blue-600 hover:underline" href="/gsap">
+                  <a class="inline-link text-blue-600 hover:underline" href="/gsap">
                     unpkg.com/gsap
                   </a>
                 </li>
@@ -207,12 +207,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 In modern packages that use{" "}
-                <a class="text-blue-600 hover:underline" href="https://nodejs.org/api/packages.html#exports">
+                <a class="inline-link text-blue-600 hover:underline" href="https://nodejs.org/api/packages.html#exports">
                   the <code class="text-sm bg-slate-100">exports</code> field
                 </a>
                 , UNPKG will resolve the file using the <code class="text-sm bg-slate-100">default</code>{" "}
                 <a
-                  class="text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 hover:underline"
                   href="https://nodejs.org/api/packages.html#conditional-exports"
                 >
                   export condition
@@ -329,14 +329,14 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
                 UNPKG is ideal for loading dependencies in apps that run entirely in the browser without a build step.
                 You can load{" "}
                 <a
-                  class="text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 hover:underline"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules"
                 >
                   JavaScript modules
                 </a>{" "}
                 from UNPKG directly in your HTML using an{" "}
                 <a
-                  class="text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 hover:underline"
                   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap"
                 >
                   import map
@@ -488,7 +488,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 For packages that are not already published as browser-ready ESM files, use{" "}
-                <a class="text-blue-600 hover:underline" href={esmUrl("/")}>
+                <a class="inline-link text-blue-600 hover:underline" href={esmUrl("/")}>
                   esm.unpkg.com
                 </a>
                 . This subdomain resolves npm packages, transforms TypeScript and JSX when needed, bundles package
@@ -532,17 +532,17 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li>
-                  <a class="text-blue-600 hover:underline break-all" href={esmUrl("/preact")}>
+                  <a class="inline-link text-blue-600 hover:underline break-all" href={esmUrl("/preact")}>
                     esm.unpkg.com/preact
                   </a>
                 </li>
                 <li>
-                  <a class="text-blue-600 hover:underline break-all" href={esmUrl("/react-dom@18/client")}>
+                  <a class="inline-link text-blue-600 hover:underline break-all" href={esmUrl("/react-dom@18/client")}>
                     esm.unpkg.com/react-dom@18/client
                   </a>
                 </li>
                 <li>
-                  <a class="text-blue-600 hover:underline break-all" href={esmUrl("/@floating-ui/dom@1")}>
+                  <a class="inline-link text-blue-600 hover:underline break-all" href={esmUrl("/@floating-ui/dom@1")}>
                     esm.unpkg.com/@floating-ui/dom@1
                   </a>
                 </li>
@@ -745,12 +745,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li>
-                  <a class="text-blue-600 hover:underline" href="/react-router@7.3.0/?meta">
+                  <a class="inline-link text-blue-600 hover:underline" href="/react-router@7.3.0/?meta">
                     unpkg.com/react-router@7.3.0/?meta
                   </a>
                 </li>
                 <li>
-                  <a class="text-blue-600 hover:underline" href="/react-router@7.3.0/dist/?meta">
+                  <a class="inline-link text-blue-600 hover:underline" href="/react-router@7.3.0/dist/?meta">
                     unpkg.com/react-router@7.3.0/dist/?meta
                   </a>
                 </li>
@@ -760,7 +760,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
                 This will return a JSON object with information about the files in that directory, including path, size,
                 type, and{" "}
                 <a
-                  class="text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 hover:underline"
                   href="https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity"
                 >
                   subresource integrity
@@ -805,11 +805,11 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-2">
                 Additionally, UNPKG runs on{" "}
-                <a class="text-blue-600 hover:underline" href="https://www.cloudflare.com">
+                <a class="inline-link text-blue-600 hover:underline" href="https://www.cloudflare.com">
                   Cloudflare's
                 </a>{" "}
                 global edge network using{" "}
-                <a class="text-blue-600 hover:underline" href="https://workers.cloudflare.com/">
+                <a class="inline-link text-blue-600 hover:underline" href="https://workers.cloudflare.com/">
                   Cloudflare Workers
                 </a>
                 , which allow UNPKG to serve billions of requests every day with low latency from hundreds of locations
@@ -836,7 +836,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-2">
                 For example, a URL like{" "}
-                <a class="text-blue-600 hover:underline" href="/preact@10">
+                <a class="inline-link text-blue-600 hover:underline" href="/preact@10">
                   unpkg.com/preact@10
                 </a>{" "}
                 will not be a direct cache hit because UNPKG needs to resolve the version{" "}
@@ -844,7 +844,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
                 that major, plus it needs to figure out which file to serve. So a short URL like this will always cause
                 a redirect to the permanent URL for that resource. If you need to make sure you hit the cache, use a
                 fixed version number and the full file path, like{" "}
-                <a class="text-blue-600 hover:underline break-all" href="/preact@10.5.0/dist/preact.min.js">
+                <a class="inline-link text-blue-600 hover:underline break-all" href="/preact@10.5.0/dist/preact.min.js">
                   unpkg.com/preact@10.5.0/dist/preact.min.js
                 </a>
                 .
@@ -856,16 +856,16 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-2">
                 UNPKG is an{" "}
-                <a class="text-blue-600 hover:underline" href="https://github.com/unpkg" title="UNPKG on GitHub">
+                <a class="inline-link text-blue-600 hover:underline" href="https://github.com/unpkg" title="UNPKG on GitHub">
                   open source project
                 </a>{" "}
                 from{" "}
-                <a class="text-blue-600 hover:underline" href="https://x.com/mjackson" title="mjackson on X">
+                <a class="inline-link text-blue-600 hover:underline" href="https://x.com/mjackson" title="mjackson on X">
                   @mjackson
                 </a>
                 . UNPKG is not affiliated with or supported by npm in any way. Please do not contact npm for help with
                 UNPKG. Instead, please reach out to{" "}
-                <a class="text-blue-600 hover:underline" href="https://x.com/unpkg" title="UNPKG on X">
+                <a class="inline-link text-blue-600 hover:underline" href="https://x.com/unpkg" title="UNPKG on X">
                   @unpkg
                 </a>{" "}
                 with any questions or concerns.

--- a/packages/unpkg-www/src/components/home.tsx
+++ b/packages/unpkg-www/src/components/home.tsx
@@ -23,7 +23,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
         <h1 class="mt-32 text-7xl text-center font-black text-black dark:text-dark-foreground">UNPKG</h1>
       </header>
 
-      <main class="mx-auto lg:max-w-screen-md text-slate-900 dark:text-dark-foreground leading-relaxed max-w-full">
+      <main class="mx-auto lg:max-w-screen-md text-lg text-slate-900 dark:text-dark-secondary leading-relaxed max-w-full">
         <div class="relative mt-16 mb-32 px-8 lg:mt-32">
           <div>
             <section id="overview">
@@ -929,7 +929,7 @@ function XIcon(props: { class?: string }): VNode {
 
 function SectionHeading({ id, children }: { id: string; children: string }): VNode {
   return (
-    <h2 class="mt-16 mb-8 text-lg font-semibold group">
+    <h2 class="mt-24 mb-8 text-xl font-semibold text-slate-900 dark:text-dark-foreground group">
       {children}{" "}
       <a
         class="section-permalink outline-none after:content-['#'] after:ml-1 after:text-slate-300 dark:after:text-dark-border-strong after:opacity-0 group-hover:after:opacity-100 after:transition-opacity"

--- a/packages/unpkg-www/src/components/home.tsx
+++ b/packages/unpkg-www/src/components/home.tsx
@@ -932,7 +932,7 @@ function SectionHeading({ id, children }: { id: string; children: string }): VNo
     <h2 class="mt-16 mb-8 text-lg font-semibold group">
       {children}{" "}
       <a
-        class="outline-none after:content-['#'] after:ml-1 after:text-slate-300 after:opacity-0 group-hover:after:opacity-100 after:transition-opacity"
+        class="outline-none after:content-['#'] after:ml-1 after:text-slate-300 after:opacity-0 group-hover:after:opacity-100 focus-visible:after:opacity-100 focus-visible:after:text-blue-600 after:transition-opacity"
         href={`#${id}`}
       />
     </h2>

--- a/packages/unpkg-www/src/components/home.tsx
+++ b/packages/unpkg-www/src/components/home.tsx
@@ -20,22 +20,22 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
   return (
     <Fragment>
       <header class="mx-auto lg:max-w-screen-md">
-        <h1 class="mt-32 text-7xl text-center font-black text-black">UNPKG</h1>
+        <h1 class="mt-32 text-7xl text-center font-black text-black dark:text-dark-foreground">UNPKG</h1>
       </header>
 
-      <main class="mx-auto lg:max-w-screen-md text-slate-900 leading-relaxed max-w-full">
+      <main class="mx-auto lg:max-w-screen-md text-slate-900 dark:text-dark-foreground leading-relaxed max-w-full">
         <div class="relative mt-16 mb-32 px-8 lg:mt-32">
           <div>
             <section id="overview">
               <p>
                 UNPKG is a fast, global content delivery network for everything on{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://www.npmjs.com/">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://www.npmjs.com/">
                   npm
                 </a>
                 . Use it to quickly and easily load any file on npm using a URL like:
               </p>
 
-              <p class="mt-12 p-4 text-center bg-slate-100">
+              <p class="mt-12 p-4 text-center bg-slate-100 dark:bg-dark-panel">
                 <code class="text-sm sm:hidden">unpkg.com/:pkg@:ver/:file</code>
                 <code class="text-sm hidden sm:block">{url("/:package@:version/:file")}</code>
               </p>
@@ -43,29 +43,29 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               <div class="mt-12 overflow-x-auto">
                 <table class="w-full text-left text-sm border-collapse">
                   <thead>
-                    <tr class="border-b border-slate-300">
+                    <tr class="border-b border-slate-300 dark:border-dark-border-strong">
                       <th class="py-2 pr-4 font-semibold">Segment</th>
                       <th class="py-2 font-semibold">Use</th>
                     </tr>
                   </thead>
                   <tbody>
-                    <tr class="border-b border-slate-200">
+                    <tr class="border-b border-slate-200 dark:border-dark-border">
                       <td class="py-2 pr-4 whitespace-nowrap align-top">
-                        <code class="text-sm bg-slate-100 sm:hidden">:pkg</code>
-                        <code class="text-sm bg-slate-100 hidden sm:inline">:package</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel sm:hidden">:pkg</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel hidden sm:inline">:package</code>
                       </td>
                       <td class="py-2 align-top">The package name on npm.</td>
                     </tr>
-                    <tr class="border-b border-slate-200">
+                    <tr class="border-b border-slate-200 dark:border-dark-border">
                       <td class="py-2 pr-4 whitespace-nowrap align-top">
-                        <code class="text-sm bg-slate-100 sm:hidden">:ver</code>
-                        <code class="text-sm bg-slate-100 hidden sm:inline">:version</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel sm:hidden">:ver</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel hidden sm:inline">:version</code>
                       </td>
                       <td class="py-2 align-top">The package version, npm dist-tag, or semver range.</td>
                     </tr>
                     <tr>
                       <td class="py-2 pr-4 whitespace-nowrap align-top">
-                        <code class="text-sm bg-slate-100">:file</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel">:file</code>
                       </td>
                       <td class="py-2 align-top">The path to a file in the package.</td>
                     </tr>
@@ -77,17 +77,17 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline break-all" href="/preact@10.26.4/dist/preact.min.js">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/preact@10.26.4/dist/preact.min.js">
                     unpkg.com/preact@10.26.4/dist/preact.min.js
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline break-all" href="/react@18.3.1/umd/react.production.min.js">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/react@18.3.1/umd/react.production.min.js">
                     unpkg.com/react@18.3.1/umd/react.production.min.js
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline break-all" href="/three@0.174.0/build/three.module.min.js">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/three@0.174.0/build/three.module.min.js">
                     unpkg.com/three@0.174.0/build/three.module.min.js
                   </a>
                 </li>
@@ -95,11 +95,11 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 You can also use any valid{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://docs.npmjs.com/about-semantic-versioning">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://docs.npmjs.com/about-semantic-versioning">
                   semver
                 </a>{" "}
                 range or{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://docs.npmjs.com/adding-dist-tags-to-packages">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://docs.npmjs.com/adding-dist-tags-to-packages">
                   npm tag
                 </a>
                 :
@@ -107,53 +107,53 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline break-all" href="/preact@latest/dist/preact.min.js">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/preact@latest/dist/preact.min.js">
                     unpkg.com/preact@latest/dist/preact.min.js
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline break-all" href="/react@^18/umd/react.production.min.js">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/react@^18/umd/react.production.min.js">
                     unpkg.com/react@^18/umd/react.production.min.js
                   </a>
                 </li>
               </ul>
 
               <p class="mt-4">
-                If you don't specify a version, the <code class="text-sm bg-slate-100">latest</code> tag is used by
+                If you don't specify a version, the <code class="text-sm bg-slate-100 dark:bg-dark-panel">latest</code> tag is used by
                 default.
               </p>
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline break-all" href="/preact/dist/preact.min.js">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/preact/dist/preact.min.js">
                     unpkg.com/preact/dist/preact.min.js
                   </a>
                 </li>
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline break-all" href="/vue/dist/vue.esm-browser.prod.js">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/vue/dist/vue.esm-browser.prod.js">
                     unpkg.com/vue/dist/vue.esm-browser.prod.js
                   </a>
                 </li>
               </ul>
 
               <p class="mt-4">
-                Add a trailing <code class="text-sm bg-slate-100">/</code> to a directory URL to view a listing of all
+                Add a trailing <code class="text-sm bg-slate-100 dark:bg-dark-panel">/</code> to a directory URL to view a listing of all
                 the files in that directory.
               </p>
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline" href="/react/">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/react/">
                     unpkg.com/react/
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline" href="/preact/src/">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/preact/src/">
                     unpkg.com/preact/src/
                   </a>
                 </li>
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline" href="/react-router/">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/react-router/">
                     unpkg.com/react-router/
                   </a>
                 </li>
@@ -165,12 +165,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline" href="/react@18/">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/react@18/">
                     unpkg.com/react@18/
                   </a>
                 </li>
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline" href="/react-router@5/">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/react-router@5/">
                     unpkg.com/react-router@5/
                   </a>
                 </li>
@@ -179,27 +179,27 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               <p class="mt-4">
                 If you don't specify a file path, UNPKG will resolve the file based on the package's default{" "}
                 <a
-                  class="inline-link text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 dark:text-dark-link hover:underline"
                   href="https://nodejs.org/api/packages.html#package-entry-points"
                 >
                   entry point
                 </a>
                 . In many packages that are meant solely for frontend development, like jQuery and GSAP, this will be
                 the value of{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://nodejs.org/api/packages.html#main">
-                  the <code class="text-sm bg-slate-100">main</code> field
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://nodejs.org/api/packages.html#main">
+                  the <code class="text-sm bg-slate-100 dark:bg-dark-panel">main</code> field
                 </a>{" "}
-                in the <code class="text-sm bg-slate-100">package.json</code> file.
+                in the <code class="text-sm bg-slate-100 dark:bg-dark-panel">package.json</code> file.
               </p>
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline" href="/jquery">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/jquery">
                     unpkg.com/jquery
                   </a>
                 </li>
                 <li class="marker:pr-2">
-                  <a class="inline-link text-blue-600 hover:underline" href="/gsap">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/gsap">
                     unpkg.com/gsap
                   </a>
                 </li>
@@ -207,12 +207,12 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 In modern packages that use{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://nodejs.org/api/packages.html#exports">
-                  the <code class="text-sm bg-slate-100">exports</code> field
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://nodejs.org/api/packages.html#exports">
+                  the <code class="text-sm bg-slate-100 dark:bg-dark-panel">exports</code> field
                 </a>
-                , UNPKG will resolve the file using the <code class="text-sm bg-slate-100">default</code>{" "}
+                , UNPKG will resolve the file using the <code class="text-sm bg-slate-100 dark:bg-dark-panel">default</code>{" "}
                 <a
-                  class="inline-link text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 dark:text-dark-link hover:underline"
                   href="https://nodejs.org/api/packages.html#conditional-exports"
                 >
                   export condition
@@ -222,7 +222,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 So, for example if you publish a package with the following{" "}
-                <code class="text-sm bg-slate-100">package.json</code>:
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">package.json</code>:
               </p>
 
               <div class="mt-8">
@@ -240,7 +240,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-8">
                 You would be able to load your package from UNPKG using a{" "}
-                <code class="text-sm bg-slate-100">&lt;script&gt;</code> tag like:
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">&lt;script&gt;</code> tag like:
               </p>
 
               <div class="mt-8">
@@ -252,8 +252,8 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               </div>
 
               <p class="mt-8">
-                The full <code class="text-sm bg-slate-100">exports</code> spec is supported, including subpaths. So if
-                your <code class="text-sm bg-slate-100">package.json</code> looks like:
+                The full <code class="text-sm bg-slate-100 dark:bg-dark-panel">exports</code> spec is supported, including subpaths. So if
+                your <code class="text-sm bg-slate-100 dark:bg-dark-panel">package.json</code> looks like:
               </p>
 
               <div class="mt-8">
@@ -272,7 +272,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               </div>
 
               <p class="mt-8">
-                You can load the <code class="text-sm bg-slate-100">exp</code> subpath with:
+                You can load the <code class="text-sm bg-slate-100 dark:bg-dark-panel">exp</code> subpath with:
               </p>
 
               <div class="mt-8">
@@ -284,9 +284,9 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               </div>
 
               <p class="mt-8">
-                Custom export conditions are supported via the <code class="text-sm bg-slate-100">?conditions</code>{" "}
+                Custom export conditions are supported via the <code class="text-sm bg-slate-100 dark:bg-dark-panel">?conditions</code>{" "}
                 query parameter. This allows you to load a different file based on the environment or other conditions.
-                For example, to fetch React using the <code class="text-sm bg-slate-100">react-server</code> condition,
+                For example, to fetch React using the <code class="text-sm bg-slate-100 dark:bg-dark-panel">react-server</code> condition,
                 you could do:
               </p>
 
@@ -300,10 +300,10 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-8">
                 If you'd like to specify a custom build of your package that should be used as the default entry point
-                on UNPKG, you can use either the <code class="text-sm bg-slate-100">unpkg</code> field in your{" "}
-                <code class="text-sm bg-slate-100">package.json</code> or the{" "}
-                <code class="text-sm bg-slate-100">unpkg</code> export condition in your{" "}
-                <code class="text-sm bg-slate-100">exports</code> field.
+                on UNPKG, you can use either the <code class="text-sm bg-slate-100 dark:bg-dark-panel">unpkg</code> field in your{" "}
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">package.json</code> or the{" "}
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">unpkg</code> export condition in your{" "}
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">exports</code> field.
               </p>
 
               <div class="mt-8">
@@ -329,14 +329,14 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
                 UNPKG is ideal for loading dependencies in apps that run entirely in the browser without a build step.
                 You can load{" "}
                 <a
-                  class="inline-link text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 dark:text-dark-link hover:underline"
                   href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules"
                 >
                   JavaScript modules
                 </a>{" "}
                 from UNPKG directly in your HTML using an{" "}
                 <a
-                  class="inline-link text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 dark:text-dark-link hover:underline"
                   href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap"
                 >
                   import map
@@ -401,10 +401,10 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               <SectionHeading id="inline-scripts">Inline Scripts</SectionHeading>
 
               <p class="mt-4">
-                UNPKG provides <code class="text-sm bg-slate-100">/run</code>, a small browser helper that scans the
-                page for inline scripts such as <code class="text-sm bg-slate-100">text/ts</code>,{" "}
-                <code class="text-sm bg-slate-100">text/jsx</code>, and{" "}
-                <code class="text-sm bg-slate-100">text/tsx</code>, transforms them through esm.unpkg.com, and inserts
+                UNPKG provides <code class="text-sm bg-slate-100 dark:bg-dark-panel">/run</code>, a small browser helper that scans the
+                page for inline scripts such as <code class="text-sm bg-slate-100 dark:bg-dark-panel">text/ts</code>,{" "}
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">text/jsx</code>, and{" "}
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">text/tsx</code>, transforms them through esm.unpkg.com, and inserts
                 executable module scripts.
               </p>
 
@@ -436,45 +436,45 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-8">
                 You can add the following attributes to inline{" "}
-                <code class="text-sm bg-slate-100">script</code> tags handled by <code>/run</code>:
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">script</code> tags handled by <code>/run</code>:
               </p>
 
               <div class="mt-8 overflow-x-auto">
                 <table class="w-full text-left text-sm border-collapse">
                   <thead>
-                    <tr class="border-b border-slate-300">
+                    <tr class="border-b border-slate-300 dark:border-dark-border-strong">
                       <th class="py-2 pr-4 font-semibold">Attribute</th>
                       <th class="py-2 font-semibold">Use</th>
                     </tr>
                   </thead>
                   <tbody>
-                    <tr class="border-b border-slate-200">
+                    <tr class="border-b border-slate-200 dark:border-dark-border">
                       <td class="py-2 pr-4 whitespace-nowrap">
-                        <code class="text-sm bg-slate-100">data-filename</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel">data-filename</code>
                       </td>
                       <td class="py-2">Names the inline file for extension inference and clearer diagnostics.</td>
                     </tr>
-                    <tr class="border-b border-slate-200">
+                    <tr class="border-b border-slate-200 dark:border-dark-border">
                       <td class="py-2 pr-4 whitespace-nowrap">
-                        <code class="text-sm bg-slate-100">data-target</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel">data-target</code>
                       </td>
                       <td class="py-2">Sets the JavaScript output target, such as <code>es2022</code>.</td>
                     </tr>
-                    <tr class="border-b border-slate-200">
+                    <tr class="border-b border-slate-200 dark:border-dark-border">
                       <td class="py-2 pr-4 whitespace-nowrap">
-                        <code class="text-sm bg-slate-100">data-jsx</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel">data-jsx</code>
                       </td>
                       <td class="py-2">Chooses JSX mode, such as <code>automatic</code>.</td>
                     </tr>
-                    <tr class="border-b border-slate-200">
+                    <tr class="border-b border-slate-200 dark:border-dark-border">
                       <td class="py-2 pr-4 whitespace-nowrap">
-                        <code class="text-sm bg-slate-100">data-jsx-import-source</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel">data-jsx-import-source</code>
                       </td>
                       <td class="py-2">Sets the JSX import source, such as <code>preact</code>.</td>
                     </tr>
                     <tr>
                       <td class="py-2 pr-4 whitespace-nowrap">
-                        <code class="text-sm bg-slate-100">data-dev</code>
+                        <code class="text-sm bg-slate-100 dark:bg-dark-panel">data-dev</code>
                       </td>
                       <td class="py-2">Enables development-mode JSX output.</td>
                     </tr>
@@ -488,7 +488,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 For packages that are not already published as browser-ready ESM files, use{" "}
-                <a class="inline-link text-blue-600 hover:underline" href={esmUrl("/")}>
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href={esmUrl("/")}>
                   esm.unpkg.com
                 </a>
                 . This subdomain resolves npm packages, transforms TypeScript and JSX when needed, bundles package
@@ -513,7 +513,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-8">
                 The URL format is the same package URL style you use on UNPKG, but on the{" "}
-                <code class="text-sm bg-slate-100">esm.unpkg.com</code> subdomain:
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">esm.unpkg.com</code> subdomain:
               </p>
 
               <div class="mt-8">
@@ -526,23 +526,23 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-8">
                 Versions may be exact versions, npm dist-tags, or semver ranges. If you omit the version, the{" "}
-                <code class="text-sm bg-slate-100">latest</code> tag is used. Requests redirect to a normalized,
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">latest</code> tag is used. Requests redirect to a normalized,
                 version-pinned URL so generated module imports are stable and cacheable.
               </p>
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline break-all" href={esmUrl("/preact")}>
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href={esmUrl("/preact")}>
                     esm.unpkg.com/preact
                   </a>
                 </li>
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline break-all" href={esmUrl("/react-dom@18/client")}>
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href={esmUrl("/react-dom@18/client")}>
                     esm.unpkg.com/react-dom@18/client
                   </a>
                 </li>
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline break-all" href={esmUrl("/@floating-ui/dom@1")}>
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href={esmUrl("/@floating-ui/dom@1")}>
                     esm.unpkg.com/@floating-ui/dom@1
                   </a>
                 </li>
@@ -550,7 +550,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-8">
                 By default, esm.unpkg.com targets modern browsers with{" "}
-                <code class="text-sm bg-slate-100">target=es2022</code>, uses production mode, bundles internal package
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">target=es2022</code>, uses production mode, bundles internal package
                 files, leaves dependency packages as rewritten imports, and attaches TypeScript declaration metadata
                 when it can find it.
               </p>
@@ -560,149 +560,149 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
               <div class="mt-4 overflow-x-auto">
                 <table class="w-full text-left text-sm border-collapse">
                   <thead>
-                    <tr class="border-b border-slate-300">
+                    <tr class="border-b border-slate-300 dark:border-dark-border-strong">
                       <th class="py-2 pr-4 font-semibold">Parameter</th>
                       <th class="py-2 font-semibold">Use</th>
                     </tr>
                   </thead>
                   <tbody>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?target=...</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?target=...</code>
                     </td>
                     <td class="py-2 align-top">
                       Chooses the output/runtime target. Supported values are{" "}
-                      <code class="text-sm bg-slate-100">es2015</code> through{" "}
-                      <code class="text-sm bg-slate-100">es2024</code>,{" "}
-                      <code class="text-sm bg-slate-100">esnext</code>,{" "}
-                      <code class="text-sm bg-slate-100">node</code>,{" "}
-                      <code class="text-sm bg-slate-100">deno</code>, and{" "}
-                      <code class="text-sm bg-slate-100">denonext</code>.
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">es2015</code> through{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">es2024</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">esnext</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">node</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">deno</code>, and{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">denonext</code>.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?dev</code>,{" "}
-                      <code class="text-sm bg-slate-100">?env=development</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?dev</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?env=development</code>
                     </td>
                     <td class="py-2 align-top">
                       Builds with development conditions and replaces{" "}
-                      <code class="text-sm bg-slate-100">process.env.NODE_ENV</code> with{" "}
-                      <code class="text-sm bg-slate-100">"development"</code>. The default is{" "}
-                      <code class="text-sm bg-slate-100">env=production</code>.
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">process.env.NODE_ENV</code> with{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">"development"</code>. The default is{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">env=production</code>.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?conditions=...</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?conditions=...</code>
                     </td>
                     <td class="py-2 align-top">
                       Adds custom package export conditions. You may pass a comma-separated list or repeat the
                       parameter.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?deps=react@18.3.1,react-dom@18.3.1</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?deps=react@18.3.1,react-dom@18.3.1</code>
                     </td>
                     <td class="py-2 align-top">Overrides dependency versions used when rewriting imports.</td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?alias=react:preact/compat</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?alias=react:preact/compat</code>
                     </td>
                     <td class="py-2 align-top">Rewrites package specifiers to alternate packages or subpaths.</td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?external=react,react-dom</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?external=react,react-dom</code>
                     </td>
                     <td class="py-2 align-top">
                       Leaves matching dependencies as bare imports. Use{" "}
-                      <code class="text-sm bg-slate-100">?external=*</code> to externalize all dependencies, or use the
-                      shorthand <code class="text-sm bg-slate-100">/*pkg</code> form, such as{" "}
-                      <code class="text-sm bg-slate-100">https://esm.unpkg.com/*swr@2</code>.
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?external=*</code> to externalize all dependencies, or use the
+                      shorthand <code class="text-sm bg-slate-100 dark:bg-dark-panel">/*pkg</code> form, such as{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">https://esm.unpkg.com/*swr@2</code>.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?bundle</code>,{" "}
-                      <code class="text-sm bg-slate-100">?standalone</code>,{" "}
-                      <code class="text-sm bg-slate-100">?no-bundle</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?bundle</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?standalone</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?no-bundle</code>
                     </td>
                     <td class="py-2 align-top">
-                      Controls dependency bundling. <code class="text-sm bg-slate-100">?bundle=false</code> also
+                      Controls dependency bundling. <code class="text-sm bg-slate-100 dark:bg-dark-panel">?bundle=false</code> also
                       disables bundling.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?jsx=automatic</code>,{" "}
-                      <code class="text-sm bg-slate-100">?jsxImportSource=...</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?jsx=automatic</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?jsxImportSource=...</code>
                     </td>
                     <td class="py-2 align-top">
-                      Selects JSX transform mode. Use <code class="text-sm bg-slate-100">?jsx=react</code> or{" "}
-                      <code class="text-sm bg-slate-100">?jsx=preact</code> for classic presets.
+                      Selects JSX transform mode. Use <code class="text-sm bg-slate-100 dark:bg-dark-panel">?jsx=react</code> or{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?jsx=preact</code> for classic presets.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?min</code>,{" "}
-                      <code class="text-sm bg-slate-100">?sourcemap</code>,{" "}
-                      <code class="text-sm bg-slate-100">?keep-names</code>,{" "}
-                      <code class="text-sm bg-slate-100">?ignore-annotations</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?min</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?sourcemap</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?keep-names</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?ignore-annotations</code>
                     </td>
                     <td class="py-2 align-top">
                       Controls output minification, inline source maps, function/class names, and tree-shaking
                       annotations.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?no-dts</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?no-dts</code>
                     </td>
                     <td class="py-2 align-top">
-                      Suppresses the <code class="text-sm bg-slate-100">X-TypeScript-Types</code> response header when
+                      Suppresses the <code class="text-sm bg-slate-100 dark:bg-dark-panel">X-TypeScript-Types</code> response header when
                       declaration files are available.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?meta</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?meta</code>
                     </td>
                     <td class="py-2 align-top">
                       Returns JSON metadata for the resolved module, including dependencies, export subpaths, target,
                       bundle mode, types URL, and integrity.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?raw</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?raw</code>
                     </td>
                     <td class="py-2 align-top">
                       Serves the raw package file without transforming it. Raw mode cannot be combined with build
-                      options like <code class="text-sm bg-slate-100">?target</code>,{" "}
-                      <code class="text-sm bg-slate-100">?bundle</code>, or{" "}
-                      <code class="text-sm bg-slate-100">?min</code>.
+                      options like <code class="text-sm bg-slate-100 dark:bg-dark-panel">?target</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?bundle</code>, or{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?min</code>.
                     </td>
                   </tr>
-                  <tr class="border-b border-slate-200">
+                  <tr class="border-b border-slate-200 dark:border-dark-border">
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?css</code>,{" "}
-                      <code class="text-sm bg-slate-100">?module</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?css</code>,{" "}
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?module</code>
                     </td>
                     <td class="py-2 align-top">
                       Requests package stylesheet entries or returns constructable stylesheet modules for{" "}
-                      <code class="text-sm bg-slate-100">.css</code> files.
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">.css</code> files.
                     </td>
                   </tr>
                   <tr>
                     <td class="py-2 pr-4 align-top break-all">
-                      <code class="text-sm bg-slate-100">?worker</code>
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">?worker</code>
                     </td>
                     <td class="py-2 align-top">
                       Returns a small module that creates a{" "}
-                      <code class="text-sm bg-slate-100">{"new Worker(url, { type: \"module\" })"}</code> for the
+                      <code class="text-sm bg-slate-100 dark:bg-dark-panel">{"new Worker(url, { type: \"module\" })"}</code> for the
                       resolved module URL.
                     </td>
                   </tr>
@@ -712,10 +712,10 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-8">
                 Stylesheet packages and stylesheet files can be loaded from the same npm URLs. Direct{" "}
-                <code class="text-sm bg-slate-100">.css</code> files are served as CSS, package roots with stylesheet
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">.css</code> files are served as CSS, package roots with stylesheet
                 metadata redirect to their stylesheet entry, and{" "}
-                <code class="text-sm bg-slate-100">?module</code> turns a CSS file into a constructable{" "}
-                <code class="text-sm bg-slate-100">CSSStyleSheet</code> module.
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">?module</code> turns a CSS file into a constructable{" "}
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">CSSStyleSheet</code> module.
               </p>
 
               <div class="mt-8">
@@ -738,19 +738,19 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-4">
                 UNPKG serves metadata about the files in a package when you append{" "}
-                <code class="text-sm bg-slate-100">?meta</code> to any package root or subdirectory URL.
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">?meta</code> to any package root or subdirectory URL.
               </p>
 
               <p class="mt-4">For example:</p>
 
               <ul class="mt-4 ml-6 list-disc list-outside">
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline" href="/react-router@7.3.0/?meta">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/react-router@7.3.0/?meta">
                     unpkg.com/react-router@7.3.0/?meta
                   </a>
                 </li>
                 <li>
-                  <a class="inline-link text-blue-600 hover:underline" href="/react-router@7.3.0/dist/?meta">
+                  <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/react-router@7.3.0/dist/?meta">
                     unpkg.com/react-router@7.3.0/dist/?meta
                   </a>
                 </li>
@@ -760,7 +760,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
                 This will return a JSON object with information about the files in that directory, including path, size,
                 type, and{" "}
                 <a
-                  class="inline-link text-blue-600 hover:underline"
+                  class="inline-link text-blue-600 dark:text-dark-link hover:underline"
                   href="https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity"
                 >
                   subresource integrity
@@ -805,11 +805,11 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-2">
                 Additionally, UNPKG runs on{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://www.cloudflare.com">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://www.cloudflare.com">
                   Cloudflare's
                 </a>{" "}
                 global edge network using{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://workers.cloudflare.com/">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://workers.cloudflare.com/">
                   Cloudflare Workers
                 </a>
                 , which allow UNPKG to serve billions of requests every day with low latency from hundreds of locations
@@ -825,7 +825,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-2">
                 URLs that do not specify a fully resolved package version number redirect to one that does. This is the{" "}
-                <code class="text-sm bg-slate-100">latest</code> version when none is specified, or the maximum
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">latest</code> version when none is specified, or the maximum
                 satisfying version when a semver range is given.{" "}
                 <span class="font-semibold">
                   For the best chance of getting a cache hit, use the full package version number and file path in your
@@ -836,15 +836,15 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-2">
                 For example, a URL like{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="/preact@10">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="/preact@10">
                   unpkg.com/preact@10
                 </a>{" "}
                 will not be a direct cache hit because UNPKG needs to resolve the version{" "}
-                <code class="text-sm bg-slate-100">10</code> to the latest matching version of Preact published with
+                <code class="text-sm bg-slate-100 dark:bg-dark-panel">10</code> to the latest matching version of Preact published with
                 that major, plus it needs to figure out which file to serve. So a short URL like this will always cause
                 a redirect to the permanent URL for that resource. If you need to make sure you hit the cache, use a
                 fixed version number and the full file path, like{" "}
-                <a class="inline-link text-blue-600 hover:underline break-all" href="/preact@10.5.0/dist/preact.min.js">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline break-all" href="/preact@10.5.0/dist/preact.min.js">
                   unpkg.com/preact@10.5.0/dist/preact.min.js
                 </a>
                 .
@@ -856,16 +856,16 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
 
               <p class="mt-2">
                 UNPKG is an{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://github.com/unpkg" title="UNPKG on GitHub">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://github.com/unpkg" title="UNPKG on GitHub">
                   open source project
                 </a>{" "}
                 from{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://x.com/mjackson" title="mjackson on X">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://x.com/mjackson" title="mjackson on X">
                   @mjackson
                 </a>
                 . UNPKG is not affiliated with or supported by npm in any way. Please do not contact npm for help with
                 UNPKG. Instead, please reach out to{" "}
-                <a class="inline-link text-blue-600 hover:underline" href="https://x.com/unpkg" title="UNPKG on X">
+                <a class="inline-link text-blue-600 dark:text-dark-link hover:underline" href="https://x.com/unpkg" title="UNPKG on X">
                   @unpkg
                 </a>{" "}
                 with any questions or concerns.
@@ -883,10 +883,10 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
         </div>
       </main>
 
-      <footer class="mx-auto lg:max-w-screen-md px-8 pt-8 pb-24 border-t border-slate-200 text-slate-600">
+      <footer class="mx-auto lg:max-w-screen-md px-8 pt-8 pb-24 border-t border-slate-200 dark:border-dark-border text-slate-600 dark:text-dark-secondary">
         <p class="flex items-center justify-center gap-4">
           <a
-            class="text-slate-600 hover:text-slate-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-slate-500"
+            class="text-slate-600 dark:text-dark-foreground hover:text-slate-950 dark:hover:text-dark-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-slate-500 dark:focus-visible:outline-dark-muted"
             href="https://github.com/unpkg"
             title="UNPKG on GitHub"
             aria-label="UNPKG on GitHub"
@@ -894,7 +894,7 @@ export function Home({ esmOrigin, origin }: { esmOrigin: string; origin: string 
             <GitHubIcon class="w-6 h-6" />
           </a>
           <a
-            class="text-slate-600 hover:text-slate-950 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-slate-500"
+            class="text-slate-600 dark:text-dark-foreground hover:text-slate-950 dark:hover:text-dark-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-slate-500 dark:focus-visible:outline-dark-muted"
             href="https://x.com/unpkg"
             title="UNPKG on X"
             aria-label="UNPKG on X"
@@ -932,7 +932,7 @@ function SectionHeading({ id, children }: { id: string; children: string }): VNo
     <h2 class="mt-16 mb-8 text-lg font-semibold group">
       {children}{" "}
       <a
-        class="section-permalink outline-none after:content-['#'] after:ml-1 after:text-slate-300 after:opacity-0 group-hover:after:opacity-100 after:transition-opacity"
+        class="section-permalink outline-none after:content-['#'] after:ml-1 after:text-slate-300 dark:after:text-dark-border-strong after:opacity-0 group-hover:after:opacity-100 after:transition-opacity"
         href={`#${id}`}
       />
     </h2>

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -119,6 +119,7 @@ describe("handleRequest", () => {
     expect(html).not.toContain('class="hljs-listing');
     expect(html).toContain("focus-visible:outline-slate-500");
     expect(html).toContain("section-permalink");
+    expect(html).toContain("inline-link text-blue-600");
     expect(html).toContain(">esm.unpkg.com/preact<");
     expect(html).toContain(">esm.unpkg.com/react-dom@18/client<");
     expect(html).toContain('href="https://github.com/unpkg"');

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -115,6 +115,7 @@ describe("handleRequest", () => {
     expect(html).toContain(">Parameter<");
     expect(html).toContain("overflow-x-auto");
     expect(html).toContain("hljs-listing");
+    expect(html).toContain("hljs-frame");
     expect(html).toContain("focus-visible:outline-slate-500");
     expect(html).toContain("focus-visible:after:text-blue-600");
     expect(html).toContain(">esm.unpkg.com/preact<");

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -101,8 +101,9 @@ describe("handleRequest", () => {
     let response = await handleRequest(new Request("https://unpkg.dev/"), stagingEnv, context);
     let html = await response.text();
 
-    expect(html).toContain('<html lang="en" style="background-color:white;">');
-    expect(html).toContain('<body style="background-color:white;">');
+    expect(html).toContain('<meta name="color-scheme" content="light dark"/>');
+    expect(html).toContain('media="(prefers-color-scheme: dark)"');
+    expect(html).toContain('code-dark.css" media="(prefers-color-scheme: dark)"');
     expect(html).toContain('href="https://esm.unpkg.dev/"');
     expect(html).toContain('href="https://esm.unpkg.dev/preact"');
     expect(html).toContain('href="https://esm.unpkg.dev/react-dom@18/client"');

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -114,10 +114,11 @@ describe("handleRequest", () => {
     expect(html).toContain(">Segment<");
     expect(html).toContain(">Parameter<");
     expect(html).toContain("overflow-x-auto");
-    expect(html).toContain("hljs-listing");
+    expect(html).toContain("hljs-dark-listing");
     expect(html).toContain("hljs-frame");
+    expect(html).not.toContain('class="hljs-listing');
     expect(html).toContain("focus-visible:outline-slate-500");
-    expect(html).toContain("focus-visible:after:text-blue-600");
+    expect(html).toContain("section-permalink");
     expect(html).toContain(">esm.unpkg.com/preact<");
     expect(html).toContain(">esm.unpkg.com/react-dom@18/client<");
     expect(html).toContain('href="https://github.com/unpkg"');

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -114,7 +114,9 @@ describe("handleRequest", () => {
     expect(html).toContain(">Segment<");
     expect(html).toContain(">Parameter<");
     expect(html).toContain("overflow-x-auto");
+    expect(html).toContain("hljs-listing");
     expect(html).toContain("focus-visible:outline-slate-500");
+    expect(html).toContain("focus-visible:after:text-blue-600");
     expect(html).toContain(">esm.unpkg.com/preact<");
     expect(html).toContain(">esm.unpkg.com/react-dom@18/client<");
     expect(html).toContain('href="https://github.com/unpkg"');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,14 +34,14 @@ importers:
         version: 7.6.3
       unpkg-worker:
         specifier: workspace:*
-        version: link:../unpkg-worker
+        version: file:packages/unpkg-worker
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250320.0
         version: 4.20250403.0
       '@ryanto/esbuild-plugin-tailwind':
-        specifier: ^0.0.1
-        version: 0.0.1(esbuild@0.24.2)(tailwindcss@4.0.0-beta.9)
+        specifier: ^0.0.3
+        version: 0.0.3(esbuild@0.24.2)(tailwindcss@4.3.3)
       '@types/bun':
         specifier: ^1.2.8
         version: 1.2.8
@@ -55,8 +55,8 @@ importers:
         specifier: ^0.24.2
         version: 0.24.2
       tailwindcss:
-        specifier: 4.0.0-beta.9
-        version: 4.0.0-beta.9
+        specifier: 4.3.3
+        version: 4.3.3
       wrangler:
         specifier: 'catalog:'
         version: 4.125.0(@cloudflare/workers-types@4.20250403.0)
@@ -74,7 +74,7 @@ importers:
         version: 6.5.12(preact@10.25.2)
       unpkg-worker:
         specifier: workspace:*
-        version: link:../unpkg-worker
+        version: file:packages/unpkg-worker
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250320.0
@@ -87,7 +87,7 @@ importers:
         version: 22.10.2
       unpkg-files:
         specifier: workspace:*
-        version: link:../unpkg-files
+        version: file:packages/unpkg-files
       wrangler:
         specifier: 'catalog:'
         version: 4.125.0(@cloudflare/workers-types@4.20250403.0)
@@ -120,7 +120,7 @@ importers:
         version: 3.1.7
       unpkg-worker:
         specifier: workspace:*
-        version: link:../unpkg-worker
+        version: file:packages/unpkg-worker
     devDependencies:
       '@types/bun':
         specifier: ^1.2.8
@@ -176,14 +176,14 @@ importers:
         version: 6.5.12(preact@10.25.2)
       unpkg-worker:
         specifier: workspace:*
-        version: link:../unpkg-worker
+        version: file:packages/unpkg-worker
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250320.0
         version: 4.20250403.0
       '@ryanto/esbuild-plugin-tailwind':
-        specifier: ^0.0.1
-        version: 0.0.1(esbuild@0.24.2)(tailwindcss@4.0.0-beta.9)
+        specifier: ^0.0.3
+        version: 0.0.3(esbuild@0.24.2)(tailwindcss@4.3.3)
       '@types/bun':
         specifier: ^1.2.8
         version: 1.2.8
@@ -194,11 +194,11 @@ importers:
         specifier: ^0.24.2
         version: 0.24.2
       tailwindcss:
-        specifier: 4.0.0-beta.9
-        version: 4.0.0-beta.9
+        specifier: 4.3.3
+        version: 4.3.3
       unpkg-files:
         specifier: workspace:*
-        version: link:../unpkg-files
+        version: file:packages/unpkg-files
       wrangler:
         specifier: 'catalog:'
         version: 4.125.0(@cloudflare/workers-types@4.20250403.0)
@@ -735,12 +735,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -754,11 +763,11 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@ryanto/esbuild-plugin-tailwind@0.0.1':
-    resolution: {integrity: sha512-j+j4gRcA2ok4i35ScYAWu0HIGnSJOQlrpHEFULbQzAWYoS3MZSTaJM1AQUPtr+9DxPITqk/wck41GelsHZzbCw==}
+  '@ryanto/esbuild-plugin-tailwind@0.0.3':
+    resolution: {integrity: sha512-hC2porLY+0nfqkgJKe8r/kVQqVxZtD7MlXtEGnq6FCZJz+l/tNMvnC8Ps8JfJPwNOJ5Jko1qSdyp6+Xj1sapSw==}
     peerDependencies:
       esbuild: '*'
-      tailwindcss: 4.0.0-beta.9
+      tailwindcss: '>= 4.0.0'
 
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
@@ -767,78 +776,90 @@ packages:
   '@speed-highlight/core@1.2.24':
     resolution: {integrity: sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==}
 
-  '@tailwindcss/node@4.0.0-beta.9':
-    resolution: {integrity: sha512-KuKNhNVU5hd2L5BkXE/twBKkMnHG4wQiHes6axhDbdcRew0/YZtvlWvMIy7QmtBWnR1lM8scPhp0RXmxK/hZdw==}
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
 
-  '@tailwindcss/oxide-android-arm64@4.0.0-beta.9':
-    resolution: {integrity: sha512-MiDpTfYvRozM+40mV2wh7GCxyEj7zIOtX3bRNaJgu0adxzZaKkylks46kBY8X91NV3ch6CQSf9Zlr0vi4U5qdw==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
 
-  '@tailwindcss/oxide-darwin-arm64@4.0.0-beta.9':
-    resolution: {integrity: sha512-SjdLul42NElqSHO5uINXylMNDx4KjtN3iB2o5nv0dFJV119DB0rxSCswgSEfigqyMXLyOAw3dwdoJIUFiw5Sdg==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tailwindcss/oxide-darwin-x64@4.0.0-beta.9':
-    resolution: {integrity: sha512-pmAs3H+pYUxAYbz2y7Q2tIfcNVlnPiikZN0SejF7JaDROg4PhQsWWpvlzHZZvD6CuyFCRXayudG8PwpJSk29dg==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
 
-  '@tailwindcss/oxide-freebsd-x64@4.0.0-beta.9':
-    resolution: {integrity: sha512-l39LttvdeeueMxuVNn1Z/cNK1YMWNzoIUgTsHCgF2vhY9tl4R+QcSwlviAkvw4AkiAC4El84pGBBVGswyWa8Rw==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [freebsd]
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.0.0-beta.9':
-    resolution: {integrity: sha512-sISzLGpVXNqOYJTo7KcdtUWQulZnW7cqFanBNbe8tCkS1KvlIuckC3MWAihLxpLrmobKh/Wv+wB1aE08VEfCww==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.0.0-beta.9':
-    resolution: {integrity: sha512-8nmeXyBchcqzQtyqjnmMxlLyxBPd+bwlnr5tDr3w6yol0z7Yrfz3T6L4QoZ4TbfhE26t6qWsUa+WQlzMJKsazg==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.0.0-beta.9':
-    resolution: {integrity: sha512-x+Vr4SnZayMj5PEFHL7MczrvjK7fYuv2LvakPfXoDYnAOmjhrjX5go3I0Q65uUPWiZxGcS/y0JgAtQqgHSKU8A==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.0.0-beta.9':
-    resolution: {integrity: sha512-4HpvDn3k5P623exDRbo9rjEXcIuHBj3ZV9YcnWJNE9QZ2vzKXGXxCxPuShTAg25JmH8z+b2whmFsnbxDqtgKhA==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-linux-x64-musl@4.0.0-beta.9':
-    resolution: {integrity: sha512-RgJrSk7uAt5QC7ez0p0uNcd/Z0yoXuBL9VvMnZVdEMDA7dcf1/zMCcFt3p2nGsGY7q2qp0hULdBEhsRP2Gq0cw==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.0.0-beta.9':
-    resolution: {integrity: sha512-FCpprAxJqDT27C2OaJTAR06+BsmHS2gW7Wu0lC9E6DwiizYP0YjSVFeYvnkluE5O2J4uVR3X2GAaqxbtG4z9Ug==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.0.0-beta.9':
-    resolution: {integrity: sha512-KOf2YKFwrvFVX+RNJsYVC6tsWBxDMTX7/u4SpUepqkwVgq2yCObx/Sqt820lXuKgGJ9dKsTYF2wvMUGom7B71A==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
     cpu: [x64]
     os: [win32]
 
-  '@tailwindcss/oxide@4.0.0-beta.9':
-    resolution: {integrity: sha512-1bpui84CDnrjB6TI3AGR9jYUA28+VIfkrM4BH3+VXA9B80+cARtd3ON06ouA5/r/2xs4qe+T85Z1c0k5X6vLeA==}
-    engines: {node: '>= 10'}
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
 
   '@types/bun@1.2.8':
     resolution: {integrity: sha512-t8L1RvJVUghW5V+M/fL3Thbxcs0HwNsXsnTEBEfEVqGteiJToOlZ/fyOEaR1kZsNqnu+3XA4RI/qmnX4w6+S+w==}
@@ -936,11 +957,6 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -951,8 +967,8 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  enhanced-resolve@5.18.0:
-    resolution: {integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==}
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
 
   error-stack-parser-es@1.0.5:
@@ -1014,77 +1030,156 @@ packages:
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
-  jiti@2.4.2:
-    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  lightningcss-darwin-arm64@1.29.1:
-    resolution: {integrity: sha512-HtR5XJ5A0lvCqYAoSv2QdZZyoHNttBpa5EP9aNuzBQeKGfbyH5+UipLWvVzpP4Uml5ej4BYs5I9Lco9u1fECqw==}
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.29.1:
-    resolution: {integrity: sha512-k33G9IzKUpHy/J/3+9MCO4e+PzaFblsgBjSGlpAaFikeBFm8B/CkO3cKU9oI4g+fjS2KlkLM/Bza9K/aw8wsNA==}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.29.1:
-    resolution: {integrity: sha512-0SUW22fv/8kln2LnIdOCmSuXnxgxVC276W5KLTwoehiO0hxkacBxjHOL5EtHD8BAXg2BvuhsJPmVMasvby3LiQ==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.29.1:
-    resolution: {integrity: sha512-sD32pFvlR0kDlqsOZmYqH/68SqUMPNj+0pucGxToXZi4XZgZmqeX/NkxNKCPsswAXU3UeYgDSpGhu05eAufjDg==}
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.29.1:
-    resolution: {integrity: sha512-0+vClRIZ6mmJl/dxGuRsE197o1HDEeeRk6nzycSy2GofC2JsY4ifCRnvUWf/CUBQmlrvMzt6SMQNMSEu22csWQ==}
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.29.1:
-    resolution: {integrity: sha512-UKMFrG4rL/uHNgelBsDwJcBqVpzNJbzsKkbI3Ja5fg00sgQnHw/VrzUTEc4jhZ+AN2BvQYz/tkHu4vt1kLuJyw==}
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-x64-gnu@1.29.1:
-    resolution: {integrity: sha512-u1S+xdODy/eEtjADqirA774y3jLcm8RPtYztwReEXoZKdzgsHYPl0s5V52Tst+GKzqjebkULT86XMSxejzfISw==}
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.29.1:
-    resolution: {integrity: sha512-L0Tx0DtaNUTzXv0lbGCLB/c/qEADanHbu4QdcNOXLIe1i8i22rZRpbT3gpWYsCh9aSL9zFujY/WmEXIatWvXbw==}
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
 
-  lightningcss-win32-arm64-msvc@1.29.1:
-    resolution: {integrity: sha512-QoOVnkIEFfbW4xPi+dpdft/zAKmgLgsRHfJalEPYuJDOWf7cLQzYg0DEh8/sn737FaeMJxHZRc1oBreiwZCjog==}
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.29.1:
-    resolution: {integrity: sha512-NygcbThNBe4JElP+olyTI/doBNGJvLs3bFCRPdvuCcxZCcCZ71B858IHpdm7L1btZex0FvCmM17FK98Y9MRy1Q==}
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.29.1:
-    resolution: {integrity: sha512-FmGoeD4S05ewj+AkhTY+D+myDvXI6eL27FjHIjoyUkO/uw7WZD1fBVs0QxeYWa7E17CUHJaYX/RUGISCtcrG4Q==}
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   miniflare@5.20260820.0-alpha:
     resolution: {integrity: sha512-Bv1j2kcKKNwXLWuCx+j0xGt7z318mqQkJmEN6ellM9sCESbPBDTM9ofZMbKqx47jSnoGA3CiaUkAmzGVXUa/wQ==}
@@ -1160,6 +1255,10 @@ packages:
     resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
     engines: {node: '>=20.9.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
@@ -1176,11 +1275,11 @@ packages:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
 
-  tailwindcss@4.0.0-beta.9:
-    resolution: {integrity: sha512-96KpsfQi+/sFIOfyFnGzyy5pobuzf1iMBD9NVtelerPM/lPI2XUS4Kikw9yuKRniXXw77ov1sl7gCSKLsn6CJA==}
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
-  tapable@2.2.1:
-    resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-stream@3.1.7:
@@ -1565,9 +1664,24 @@ snapshots:
   '@img/sharp-win32-x64@0.35.2':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -1586,70 +1700,78 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@ryanto/esbuild-plugin-tailwind@0.0.1(esbuild@0.24.2)(tailwindcss@4.0.0-beta.9)':
+  '@ryanto/esbuild-plugin-tailwind@0.0.3(esbuild@0.24.2)(tailwindcss@4.3.3)':
     dependencies:
-      '@tailwindcss/node': 4.0.0-beta.9
-      '@tailwindcss/oxide': 4.0.0-beta.9
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
       esbuild: 0.24.2
-      lightningcss: 1.29.1
-      tailwindcss: 4.0.0-beta.9
+      lightningcss: 1.33.0
+      tailwindcss: 4.3.3
 
   '@sindresorhus/is@7.2.0': {}
 
   '@speed-highlight/core@1.2.24': {}
 
-  '@tailwindcss/node@4.0.0-beta.9':
+  '@tailwindcss/node@4.3.3':
     dependencies:
-      enhanced-resolve: 5.18.0
-      jiti: 2.4.2
-      tailwindcss: 4.0.0-beta.9
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
 
-  '@tailwindcss/oxide-android-arm64@4.0.0-beta.9':
+  '@tailwindcss/oxide-android-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-arm64@4.0.0-beta.9':
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-darwin-x64@4.0.0-beta.9':
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-freebsd-x64@4.0.0-beta.9':
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm-gnueabihf@4.0.0-beta.9':
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-gnu@4.0.0-beta.9':
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-arm64-musl@4.0.0-beta.9':
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-gnu@4.0.0-beta.9':
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-linux-x64-musl@4.0.0-beta.9':
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-arm64-msvc@4.0.0-beta.9':
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide-win32-x64-msvc@4.0.0-beta.9':
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
     optional: true
 
-  '@tailwindcss/oxide@4.0.0-beta.9':
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
     optionalDependencies:
-      '@tailwindcss/oxide-android-arm64': 4.0.0-beta.9
-      '@tailwindcss/oxide-darwin-arm64': 4.0.0-beta.9
-      '@tailwindcss/oxide-darwin-x64': 4.0.0-beta.9
-      '@tailwindcss/oxide-freebsd-x64': 4.0.0-beta.9
-      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.0.0-beta.9
-      '@tailwindcss/oxide-linux-arm64-gnu': 4.0.0-beta.9
-      '@tailwindcss/oxide-linux-arm64-musl': 4.0.0-beta.9
-      '@tailwindcss/oxide-linux-x64-gnu': 4.0.0-beta.9
-      '@tailwindcss/oxide-linux-x64-musl': 4.0.0-beta.9
-      '@tailwindcss/oxide-win32-arm64-msvc': 4.0.0-beta.9
-      '@tailwindcss/oxide-win32-x64-msvc': 4.0.0-beta.9
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
   '@types/bun@1.2.8':
     dependencies:
@@ -1730,8 +1852,6 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  detect-libc@1.0.3: {}
-
   detect-libc@2.1.2: {}
 
   duplexify@3.7.1:
@@ -1745,10 +1865,10 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.18.0:
+  enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.2.1
+      tapable: 2.3.3
 
   error-stack-parser-es@1.0.5: {}
 
@@ -1848,54 +1968,111 @@ snapshots:
 
   isarray@1.0.0: {}
 
-  jiti@2.4.2: {}
+  jiti@2.7.0: {}
 
   kleur@4.1.5: {}
 
-  lightningcss-darwin-arm64@1.29.1:
+  lightningcss-android-arm64@1.32.0:
     optional: true
 
-  lightningcss-darwin-x64@1.29.1:
+  lightningcss-android-arm64@1.33.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.29.1:
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.29.1:
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.29.1:
+  lightningcss-darwin-x64@1.32.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.29.1:
+  lightningcss-darwin-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.29.1:
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.29.1:
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.29.1:
+  lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.29.1:
+  lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
-  lightningcss@1.29.1:
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.32.0:
     dependencies:
-      detect-libc: 1.0.3
+      detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-darwin-arm64: 1.29.1
-      lightningcss-darwin-x64: 1.29.1
-      lightningcss-freebsd-x64: 1.29.1
-      lightningcss-linux-arm-gnueabihf: 1.29.1
-      lightningcss-linux-arm64-gnu: 1.29.1
-      lightningcss-linux-arm64-musl: 1.29.1
-      lightningcss-linux-x64-gnu: 1.29.1
-      lightningcss-linux-x64-musl: 1.29.1
-      lightningcss-win32-arm64-msvc: 1.29.1
-      lightningcss-win32-x64-msvc: 1.29.1
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   miniflare@5.20260820.0-alpha:
     dependencies:
@@ -2004,6 +2181,8 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.2
       '@img/sharp-win32-x64': 0.35.2
 
+  source-map-js@1.2.1: {}
+
   stream-shift@1.0.3: {}
 
   streamx@2.22.0:
@@ -2028,9 +2207,9 @@ snapshots:
 
   supports-color@10.2.2: {}
 
-  tailwindcss@4.0.0-beta.9: {}
+  tailwindcss@4.3.3: {}
 
-  tapable@2.2.1: {}
+  tapable@2.3.3: {}
 
   tar-stream@3.1.7:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ onlyBuiltDependencies:
   - esbuild
   - sharp
   - workerd
+syncInjectedDepsAfterScripts:
+  - build


### PR DESCRIPTION
UNPKG now follows each visitor's system color-scheme preference across the documentation site, package browser, source viewer, and ESM landing page. Dark mode uses a restrained layered-black hierarchy and requires no opt-in.

- advertises light and dark support before paint and supplies matching browser theme colors
- upgrades www and app from the Tailwind v4 beta to stable Tailwind `4.3.3` and the compatible esbuild adapter
- preserves the light palette and UNPKG's original sans-serif font stack
- defines named additive Tailwind dark colors and applies them through explicit `dark:` variants without redefining built-in colors
- uses `#1a1a1a` for the canvas, `#222` for raised panels, and pure black for headers and code
- uses opacity-based secondary and muted text colors with accessible contrast
- improves shared rhythm with 18px documentation copy, wider section spacing, and 32px app gutters on desktop
- applies the official [Andromeda](https://github.com/EliverLara/Andromeda) editor palette, including its base foreground, to highlighted code
- reserves underlined Andromeda blue for inline text links while keeping header and footer links white
- preserves syntax contrast on selected source lines and adds visible keyboard focus to line and section permalinks
- keeps the standalone ESM page visually consistent with the bundled www and app surfaces

<img width="682" height="759" alt="Screenshot 2026-08-22 at 8 13 56 AM" src="https://github.com/user-attachments/assets/7fbe923d-85e6-4de9-b4e0-b7916fcba7f7" />
