### PR TITLE
Handle transient Worker network failures

### DIFF
--- a/packages/unpkg-app/src/worker.test.ts
+++ b/packages/unpkg-app/src/worker.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+
+import type { Env } from "./env.ts";
+import worker from "./worker.ts";
+
+const env: Env = {
+  ASSETS_ORIGIN: "https://app.unpkg.com",
+  DEV: false,
+  FILES_ORIGIN: "https://files.unpkg.com",
+  MODE: "test",
+  ORIGIN: "https://app.unpkg.com",
+  WWW_ORIGIN: "https://unpkg.com",
+};
+
+const context = {
+  waitUntil() {},
+} as unknown as ExecutionContext;
+
+let originalCaches = globalThis.caches;
+
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
+
+describe("worker", () => {
+  it("returns a retryable 503 when the cache connection remains unavailable", async () => {
+    globalThis.caches = {
+      default: {
+        async match() {
+          throw new Error("Network connection lost.");
+        },
+      },
+    } as unknown as CacheStorage;
+    let error = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      let response = await worker.fetch(new Request("https://app.unpkg.com/example"), env, context);
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("1");
+    } finally {
+      error.mockRestore();
+    }
+  });
+});

--- a/packages/unpkg-app/src/worker.ts
+++ b/packages/unpkg-app/src/worker.ts
@@ -1,21 +1,22 @@
-import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "unpkg-worker";
+import {
+  isCacheableResponse,
+  isNetworkConnectionLostError,
+  retryOnNetworkConnectionLost,
+  waitUntilCachePut,
+} from "unpkg-worker";
 
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.tsx";
 
-// @ts-expect-error - `caches.default` is missing in @cloudflare/workers-types
-const cache = caches.default as Cache;
-
 export default {
   async fetch(request, env, context) {
     try {
+      // @ts-expect-error - `caches.default` is missing in @cloudflare/workers-types
+      let cache = caches.default as Cache;
       let response = await retryOnNetworkConnectionLost(() => cache.match(request));
 
       if (!response) {
-        response =
-          request.method === "GET" || request.method === "HEAD"
-            ? await retryOnNetworkConnectionLost(() => handleRequest(request, env, context))
-            : await handleRequest(request, env, context);
+        response = await handleRequest(request, env, context);
 
         if (isCacheableResponse(request, response)) {
           waitUntilCachePut(context, cache, request, response.clone(), "unpkg-app");
@@ -29,6 +30,13 @@ export default {
       return response;
     } catch (error) {
       console.error(error);
+
+      if (isNetworkConnectionLostError(error)) {
+        return new Response("Service Unavailable", {
+          status: 503,
+          headers: { "Retry-After": "1" },
+        });
+      }
 
       return new Response("Internal Server Error", { status: 500 });
     }

--- a/packages/unpkg-app/src/worker.ts
+++ b/packages/unpkg-app/src/worker.ts
@@ -1,3 +1,5 @@
+import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "unpkg-worker";
+
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.tsx";
 
@@ -7,13 +9,16 @@ const cache = caches.default as Cache;
 export default {
   async fetch(request, env, context) {
     try {
-      let response = await cache.match(request);
+      let response = await retryOnNetworkConnectionLost(() => cache.match(request));
 
       if (!response) {
-        response = await handleRequest(request, env, context);
+        response =
+          request.method === "GET" || request.method === "HEAD"
+            ? await retryOnNetworkConnectionLost(() => handleRequest(request, env, context))
+            : await handleRequest(request, env, context);
 
-        if (request.method === "GET" && response.status === 200 && response.headers.has("Cache-Control")) {
-          context.waitUntil(cache.put(request, response.clone()));
+        if (isCacheableResponse(request, response)) {
+          waitUntilCachePut(context, cache, request, response.clone(), "unpkg-app");
         }
       }
 

--- a/packages/unpkg-esm/src/request-handler.ts
+++ b/packages/unpkg-esm/src/request-handler.ts
@@ -2,10 +2,12 @@ import {
   getEsmPackageSubpath,
   getPackageInfo,
   normalizeEsmRequestUrl,
+  readResponseWithNetworkRetry,
+  retryOnNetworkConnectionLost,
   resolvePackageExport,
   resolvePackageVersion,
 } from "unpkg-worker";
-import type { EsmRequestError, PackageJson } from "unpkg-worker";
+import type { BufferedResponse, EsmRequestError, PackageJson } from "unpkg-worker";
 
 import { createHomePage } from "./components/home-page.tsx";
 import type { Env } from "./env.ts";
@@ -207,13 +209,18 @@ export async function handleRequest(request: Request, env: Env, context: Executi
 
   let buildSearchParams = new URLSearchParams(searchParams);
   buildSearchParams.set("origin", normalized.url.origin);
-  let buildResponse = await fetch(
-    new URL(`/build/${packageName}@${version}${packagePath.filename ?? ""}${normalizeSearch(buildSearchParams)}`, env.FILES_ORIGIN)
+  let { body: buildBody, response: buildResponse } = await readResponseWithNetworkRetry(() =>
+    fetch(
+      new URL(
+        `/build/${packageName}@${version}${packagePath.filename ?? ""}${normalizeSearch(buildSearchParams)}`,
+        env.FILES_ORIGIN
+      )
+    )
   );
   if (!buildResponse.ok) {
     return jsonError({
       code: "BUILD_FAILED",
-      message: await buildResponse.text(),
+      message: new TextDecoder().decode(buildBody),
       status: buildResponse.status,
     });
   }
@@ -227,7 +234,7 @@ export async function handleRequest(request: Request, env: Env, context: Executi
     headers.set("X-TypeScript-Types", types);
   }
 
-  return new Response(await buildResponse.arrayBuffer(), {
+  return new Response(buildBody, {
     status: buildResponse.status,
     statusText: buildResponse.statusText,
     headers,
@@ -309,21 +316,25 @@ async function getBuildIntegrity(
 
   let buildSearchParams = new URLSearchParams(searchParams);
   buildSearchParams.set("origin", origin);
-  let response: Response;
+  let result: BufferedResponse;
   try {
-    response = await fetch(
-      new URL(`/build/${packageName}@${version}${filename ?? ""}${normalizeSearch(buildSearchParams)}`, env.FILES_ORIGIN)
+    result = await readResponseWithNetworkRetry(() =>
+      fetch(
+        new URL(`/build/${packageName}@${version}${filename ?? ""}${normalizeSearch(buildSearchParams)}`, env.FILES_ORIGIN)
+      )
     );
   } catch {
     return { value: null };
   }
+
+  let { body, response } = result;
 
   if (!response.ok) {
     if (response.status === 404) {
       return {
         response: jsonError({
           code: "BUILD_NOT_FOUND",
-          message: await response.text(),
+          message: new TextDecoder().decode(body),
           status: 404,
         }),
       };
@@ -332,17 +343,18 @@ async function getBuildIntegrity(
     return { value: null };
   }
 
-  let bytes = await response.arrayBuffer();
-  let digest = await crypto.subtle.digest("SHA-384", bytes);
+  let digest = await crypto.subtle.digest("SHA-384", body);
   return { value: `sha384-${base64Encode(new Uint8Array(digest))}` };
 }
 
 async function serveRawFile(env: Env, packageName: string, version: string, filename: string): Promise<Response> {
-  let rawResponse = await fetch(new URL(`/file/${packageName}@${version}${filename}`, env.FILES_ORIGIN));
+  let { body, response: rawResponse } = await readResponseWithNetworkRetry(() =>
+    fetch(new URL(`/file/${packageName}@${version}${filename}`, env.FILES_ORIGIN))
+  );
   if (!rawResponse.ok) {
     return jsonError({
       code: "RAW_FILE_NOT_FOUND",
-      message: await rawResponse.text(),
+      message: new TextDecoder().decode(body),
       status: rawResponse.status,
     });
   }
@@ -357,7 +369,7 @@ async function serveRawFile(env: Env, packageName: string, version: string, file
     headers.set(name, value);
   }
 
-  return new Response(await rawResponse.arrayBuffer(), {
+  return new Response(body, {
     status: rawResponse.status,
     statusText: rawResponse.statusText,
     headers,
@@ -458,7 +470,9 @@ async function resolveRawPath(
 }
 
 async function rawFileExists(env: Env, packageName: string, version: string, filename: string): Promise<boolean> {
-  let response = await fetch(new URL(`/file/${packageName}@${version}${filename}`, env.FILES_ORIGIN));
+  let response = await retryOnNetworkConnectionLost(() =>
+    fetch(new URL(`/file/${packageName}@${version}${filename}`, env.FILES_ORIGIN))
+  );
   return response.ok;
 }
 

--- a/packages/unpkg-esm/src/worker.test.ts
+++ b/packages/unpkg-esm/src/worker.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+
+import type { Env } from "./env.ts";
+import worker from "./worker.ts";
+
+const env: Env = {
+  FILES_ORIGIN: "https://files.unpkg.com",
+  MODE: "production",
+  ORIGIN: "https://esm.unpkg.com",
+  WWW_ORIGIN: "https://unpkg.com",
+};
+
+const context = {
+  waitUntil() {},
+} as unknown as ExecutionContext;
+
+let originalCaches = globalThis.caches;
+
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
+
+describe("worker", () => {
+  it("returns a retryable 503 when the cache connection remains unavailable", async () => {
+    globalThis.caches = {
+      default: {
+        async match() {
+          throw new Error("Network connection lost.");
+        },
+      },
+    } as unknown as CacheStorage;
+    let error = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      let response = await worker.fetch(new Request("https://esm.unpkg.com/example"), env, context);
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("1");
+    } finally {
+      error.mockRestore();
+    }
+  });
+});

--- a/packages/unpkg-esm/src/worker.ts
+++ b/packages/unpkg-esm/src/worker.ts
@@ -1,24 +1,25 @@
-import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "unpkg-worker";
+import {
+  isCacheableResponse,
+  isNetworkConnectionLostError,
+  retryOnNetworkConnectionLost,
+  waitUntilCachePut,
+} from "unpkg-worker";
 
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.ts";
 
-// @ts-expect-error - `caches.default` is missing in @cloudflare/workers-types
-const cache = caches.default as Cache;
-
 export default {
   async fetch(request, env, context) {
     try {
+      // @ts-expect-error - `caches.default` is missing in @cloudflare/workers-types
+      let cache = caches.default as Cache;
       let url = new URL(request.url);
       let shouldUseCache =
         env.MODE !== "development" && env.MODE !== "test" && url.pathname !== "/" && url.pathname !== "/index.html";
       let response = shouldUseCache ? await retryOnNetworkConnectionLost(() => cache.match(request)) : undefined;
 
       if (!response) {
-        response =
-          request.method === "GET" || request.method === "HEAD"
-            ? await retryOnNetworkConnectionLost(() => handleRequest(request, env, context))
-            : await handleRequest(request, env, context);
+        response = await handleRequest(request, env, context);
 
         if (shouldUseCache && isCacheableResponse(request, response)) {
           waitUntilCachePut(context, cache, request, response.clone(), "unpkg-esm");
@@ -32,6 +33,13 @@ export default {
       return response;
     } catch (error) {
       console.error(error);
+
+      if (isNetworkConnectionLostError(error)) {
+        return new Response("Service Unavailable", {
+          status: 503,
+          headers: { "Retry-After": "1" },
+        });
+      }
 
       return new Response("Internal Server Error", { status: 500 });
     }

--- a/packages/unpkg-esm/src/worker.ts
+++ b/packages/unpkg-esm/src/worker.ts
@@ -1,3 +1,5 @@
+import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "unpkg-worker";
+
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.ts";
 
@@ -10,13 +12,16 @@ export default {
       let url = new URL(request.url);
       let shouldUseCache =
         env.MODE !== "development" && env.MODE !== "test" && url.pathname !== "/" && url.pathname !== "/index.html";
-      let response = shouldUseCache ? await cache.match(request) : undefined;
+      let response = shouldUseCache ? await retryOnNetworkConnectionLost(() => cache.match(request)) : undefined;
 
       if (!response) {
-        response = await handleRequest(request, env, context);
+        response =
+          request.method === "GET" || request.method === "HEAD"
+            ? await retryOnNetworkConnectionLost(() => handleRequest(request, env, context))
+            : await handleRequest(request, env, context);
 
-        if (shouldUseCache && request.method === "GET" && response.status === 200 && response.headers.has("Cache-Control")) {
-          context.waitUntil(cache.put(request, response.clone()));
+        if (shouldUseCache && isCacheableResponse(request, response)) {
+          waitUntilCachePut(context, cache, request, response.clone(), "unpkg-esm");
         }
       }
 

--- a/packages/unpkg-worker/src/lib/cache-utils.test.ts
+++ b/packages/unpkg-worker/src/lib/cache-utils.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, spyOn } from "bun:test";
 
-import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "./cache-utils.ts";
+import {
+  isCacheableResponse,
+  isNetworkConnectionLostError,
+  readResponseWithNetworkRetry,
+  retryOnNetworkConnectionLost,
+  waitUntilCachePut,
+} from "./cache-utils.ts";
 
 describe("isCacheableResponse", () => {
   let request = new Request("https://unpkg.com/react");
@@ -84,5 +90,37 @@ describe("retryOnNetworkConnectionLost", () => {
 
     await expect(retryOnNetworkConnectionLost(operation, 0)).rejects.toThrow("Invalid response");
     expect(attempts).toBe(1);
+  });
+});
+
+describe("isNetworkConnectionLostError", () => {
+  it("accepts Cloudflare's message with or without punctuation", () => {
+    expect(isNetworkConnectionLostError(new Error("Network connection lost."))).toBe(true);
+    expect(isNetworkConnectionLostError(new Error("Network connection lost"))).toBe(true);
+    expect(isNetworkConnectionLostError(new Error("Connection reset"))).toBe(false);
+  });
+});
+
+describe("readResponseWithNetworkRetry", () => {
+  it("retries when the connection is lost while reading the response body", async () => {
+    let attempts = 0;
+
+    let result = await readResponseWithNetworkRetry(async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error("Network connection lost."));
+            },
+          })
+        );
+      }
+
+      return new Response("ok");
+    });
+
+    expect(new TextDecoder().decode(result.body)).toBe("ok");
+    expect(attempts).toBe(2);
   });
 });

--- a/packages/unpkg-worker/src/lib/cache-utils.test.ts
+++ b/packages/unpkg-worker/src/lib/cache-utils.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, spyOn } from "bun:test";
+
+import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "./cache-utils.ts";
+
+describe("isCacheableResponse", () => {
+  let request = new Request("https://unpkg.com/react");
+
+  it.each([200, 301, 302])("caches status %d responses with cache control", (status) => {
+    let response = new Response(null, {
+      status,
+      headers: { "Cache-Control": "public, max-age=60" },
+    });
+
+    expect(isCacheableResponse(request, response)).toBe(true);
+  });
+
+  it("does not cache responses without cache control", () => {
+    expect(isCacheableResponse(request, new Response(null))).toBe(false);
+  });
+
+  it("does not cache non-GET requests", () => {
+    let postRequest = new Request(request, { method: "POST" });
+    let response = new Response(null, {
+      headers: { "Cache-Control": "public, max-age=60" },
+    });
+
+    expect(isCacheableResponse(postRequest, response)).toBe(false);
+  });
+});
+
+describe("waitUntilCachePut", () => {
+  it("handles transient cache write failures without rejecting the invocation", async () => {
+    let pending: Promise<unknown> | undefined;
+    let context = {
+      waitUntil(promise: Promise<unknown>) {
+        pending = promise;
+      },
+    } as unknown as ExecutionContext;
+    let cache = {
+      async put() {
+        throw new Error("Network connection lost.");
+      },
+    } as unknown as Cache;
+    let warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      waitUntilCachePut(
+        context,
+        cache,
+        new Request("https://registry.npmjs.org/react"),
+        Response.json({}),
+        "npm-info"
+      );
+
+      expect(pending).toBeDefined();
+      await expect(pending!).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledWith("Cache write failed (npm-info): Network connection lost.");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe("retryOnNetworkConnectionLost", () => {
+  it("retries one transient connection failure", async () => {
+    let attempts = 0;
+
+    let result = await retryOnNetworkConnectionLost(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("Network connection lost.");
+      return "ok";
+    }, 0);
+
+    expect(result).toBe("ok");
+    expect(attempts).toBe(2);
+  });
+
+  it("does not retry other errors", async () => {
+    let attempts = 0;
+    let operation = async () => {
+      attempts += 1;
+      throw new Error("Invalid response");
+    };
+
+    await expect(retryOnNetworkConnectionLost(operation, 0)).rejects.toThrow("Invalid response");
+    expect(attempts).toBe(1);
+  });
+});

--- a/packages/unpkg-worker/src/lib/cache-utils.ts
+++ b/packages/unpkg-worker/src/lib/cache-utils.ts
@@ -11,3 +11,56 @@ export function createCacheableResponse(response: Response): Response {
     headers,
   });
 }
+
+export function isCacheableResponse(request: Request, response: Response): boolean {
+  return (
+    request.method === "GET" &&
+    (response.status === 200 || response.status === 301 || response.status === 302) &&
+    response.headers.has("Cache-Control")
+  );
+}
+
+export function waitUntilCachePut(
+  context: ExecutionContext,
+  cache: Cache,
+  request: Request,
+  response: Response,
+  cacheName: string
+): void {
+  context.waitUntil(
+    cache.put(request, response).catch((error: unknown) => {
+      if (isNetworkConnectionLostError(error)) {
+        console.warn(`Cache write failed (${cacheName}): ${getErrorMessage(error)}`);
+      } else {
+        console.error(`Cache write failed (${cacheName}):`, error);
+      }
+    })
+  );
+}
+
+export async function retryOnNetworkConnectionLost<T>(
+  operation: () => Promise<T>,
+  retryDelayMs = 25 + Math.floor(Math.random() * 50)
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isNetworkConnectionLostError(error)) {
+      throw error;
+    }
+  }
+
+  if (retryDelayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+  }
+
+  return operation();
+}
+
+function isNetworkConnectionLostError(error: unknown): boolean {
+  return getErrorMessage(error).replace(/\.$/, "") === "Network connection lost";
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/unpkg-worker/src/lib/cache-utils.ts
+++ b/packages/unpkg-worker/src/lib/cache-utils.ts
@@ -1,15 +1,20 @@
-export function createCacheableResponse(response: Response): Response {
-  let clone = response.clone();
-  let headers = new Headers(clone.headers);
+export function createCacheableResponse(response: Response, body?: BodyInit | null): Response {
+  let source = body === undefined ? response.clone() : response;
+  let headers = new Headers(source.headers);
 
   // Cloudflare cannot cache responses with Set-Cookie headers
   // See https://developers.cloudflare.com/workers/runtime-apis/cache/
   headers.delete("Set-Cookie");
 
-  return new Response(clone.body, {
-    status: clone.status,
+  return new Response(body === undefined ? source.body : body, {
+    status: source.status,
     headers,
   });
+}
+
+export interface BufferedResponse {
+  body: ArrayBuffer;
+  response: Response;
 }
 
 export function isCacheableResponse(request: Request, response: Response): boolean {
@@ -57,7 +62,28 @@ export async function retryOnNetworkConnectionLost<T>(
   return operation();
 }
 
-function isNetworkConnectionLostError(error: unknown): boolean {
+export async function readResponseWithNetworkRetry(operation: () => Promise<Response>): Promise<BufferedResponse> {
+  return retryOnNetworkConnectionLost(async () => {
+    let response = await operation();
+    let body = await response.arrayBuffer();
+
+    return { body, response };
+  });
+}
+
+export async function readOptionalResponseWithNetworkRetry(
+  operation: () => Promise<Response | undefined>
+): Promise<BufferedResponse | undefined> {
+  return retryOnNetworkConnectionLost(async () => {
+    let response = await operation();
+    if (response == null) return undefined;
+
+    let body = await response.arrayBuffer();
+    return { body, response };
+  });
+}
+
+export function isNetworkConnectionLostError(error: unknown): boolean {
   return getErrorMessage(error).replace(/\.$/, "") === "Network connection lost";
 }
 

--- a/packages/unpkg-worker/src/lib/npm-files.ts
+++ b/packages/unpkg-worker/src/lib/npm-files.ts
@@ -1,4 +1,10 @@
-import { createCacheableResponse, waitUntilCachePut } from "./cache-utils.ts";
+import {
+  createCacheableResponse,
+  readOptionalResponseWithNetworkRetry,
+  readResponseWithNetworkRetry,
+  retryOnNetworkConnectionLost,
+  waitUntilCachePut,
+} from "./cache-utils.ts";
 
 export interface PackageFile {
   path: string;
@@ -17,6 +23,11 @@ export interface PackageFileListing {
   files: PackageFileMetadata[];
 }
 
+export interface PackageFileResponse {
+  body: ArrayBuffer;
+  response: Response;
+}
+
 export async function fetchFile(
   context: ExecutionContext,
   origin: string,
@@ -24,6 +35,17 @@ export async function fetchFile(
   version: string,
   filename: string
 ): Promise<Response | null> {
+  let result = await fetchFileResponse(context, origin, packageName, version, filename);
+  return result == null ? null : new Response(result.body, result.response);
+}
+
+export async function fetchFileResponse(
+  context: ExecutionContext,
+  origin: string,
+  packageName: string,
+  version: string,
+  filename: string
+): Promise<PackageFileResponse | null> {
   if (filename === "" || filename === "/") {
     return null;
   }
@@ -31,25 +53,31 @@ export async function fetchFile(
   let url = new URL(`/file/${packageName.toLowerCase()}@${version}${filename}`, origin);
   let request = new Request(url);
 
-  let cache = await caches.open("npm-files");
-  let response = await cache.match(request);
-  if (!response) {
-    response = await fetch(request);
+  let cache = await retryOnNetworkConnectionLost(() => caches.open("npm-files"));
+  let result = await readOptionalResponseWithNetworkRetry(() => cache.match(request));
+  if (result == null) {
+    result = await readResponseWithNetworkRetry(() => fetch(request));
 
-    if (response.ok) {
-      waitUntilCachePut(context, cache, request, createCacheableResponse(response), "npm-files");
+    if (result.response.ok) {
+      waitUntilCachePut(
+        context,
+        cache,
+        request,
+        createCacheableResponse(result.response, result.body),
+        "npm-files"
+      );
     }
   }
 
-  if (!response.ok) {
-    if (response.status === 404) {
+  if (!result.response.ok) {
+    if (result.response.status === 404) {
       return null;
     }
 
-    throw new Error(`Failed to fetch file: ${response.status} ${response.statusText}`);
+    throw new Error(`Failed to fetch file: ${result.response.status} ${result.response.statusText}`);
   }
 
-  return response;
+  return result;
 }
 
 export async function getFile(
@@ -59,22 +87,22 @@ export async function getFile(
   version: string,
   filename: string
 ): Promise<PackageFile | null> {
-  let response = await fetchFile(context, origin, packageName, version, filename);
+  let result = await fetchFileResponse(context, origin, packageName, version, filename);
 
-  if (response == null) {
+  if (result == null) {
     return null;
   }
 
   let path = filename;
-  let body = new Uint8Array(await response.arrayBuffer());
+  let body = new Uint8Array(result.body);
   let size = body.length;
 
-  let type = response.headers.get("Content-Type");
+  let type = result.response.headers.get("Content-Type");
   if (type == null) {
     throw new Error(`Missing Content-Type header for file: "${filename}"`);
   }
 
-  let digest = response.headers.get("Content-Digest");
+  let digest = result.response.headers.get("Content-Digest");
   if (digest == null) {
     throw new Error(`Missing Content-Digest header for file: "${filename}"`);
   }
@@ -100,22 +128,28 @@ export async function listFiles(
   let url = new URL(`/list/${packageName.toLowerCase()}@${version}${prefix}`, origin);
   let request = new Request(url);
 
-  let cache = await caches.open("npm-file-listings");
-  let response = await cache.match(request);
+  let cache = await retryOnNetworkConnectionLost(() => caches.open("npm-file-listings"));
+  let result = await readOptionalResponseWithNetworkRetry(() => cache.match(request));
 
-  if (!response) {
-    response = await fetch(request);
+  if (result == null) {
+    result = await readResponseWithNetworkRetry(() => fetch(request));
 
-    if (response.ok) {
-      waitUntilCachePut(context, cache, request, createCacheableResponse(response), "npm-file-listings");
+    if (result.response.ok) {
+      waitUntilCachePut(
+        context,
+        cache,
+        request,
+        createCacheableResponse(result.response, result.body),
+        "npm-file-listings"
+      );
     }
   }
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch file listing: ${response.status} ${response.statusText}`);
+  if (!result.response.ok) {
+    throw new Error(`Failed to fetch file listing: ${result.response.status} ${result.response.statusText}`);
   }
 
-  let json = (await response.json()) as PackageFileListing;
+  let json = JSON.parse(new TextDecoder().decode(result.body)) as PackageFileListing;
 
   if (json.files == null) {
     throw new Error(`Invalid response format: ${JSON.stringify(json)}`);

--- a/packages/unpkg-worker/src/lib/npm-files.ts
+++ b/packages/unpkg-worker/src/lib/npm-files.ts
@@ -1,4 +1,4 @@
-import { createCacheableResponse } from "./cache-utils.ts";
+import { createCacheableResponse, waitUntilCachePut } from "./cache-utils.ts";
 
 export interface PackageFile {
   path: string;
@@ -37,7 +37,7 @@ export async function fetchFile(
     response = await fetch(request);
 
     if (response.ok) {
-      context.waitUntil(cache.put(request, createCacheableResponse(response)));
+      waitUntilCachePut(context, cache, request, createCacheableResponse(response), "npm-files");
     }
   }
 
@@ -107,7 +107,7 @@ export async function listFiles(
     response = await fetch(request);
 
     if (response.ok) {
-      context.waitUntil(cache.put(request, createCacheableResponse(response)));
+      waitUntilCachePut(context, cache, request, createCacheableResponse(response), "npm-file-listings");
     }
   }
 

--- a/packages/unpkg-worker/src/lib/npm-info.test.ts
+++ b/packages/unpkg-worker/src/lib/npm-info.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { getPackageInfo } from "./npm-info.ts";
+
+const context = {
+  waitUntil() {},
+} as unknown as ExecutionContext;
+
+let originalCaches = globalThis.caches;
+
+afterEach(() => {
+  globalThis.caches = originalCaches;
+});
+
+describe("getPackageInfo", () => {
+  it("retries transient named-cache open and read failures", async () => {
+    let openAttempts = 0;
+    let matchAttempts = 0;
+    let cache = {
+      async match() {
+        matchAttempts += 1;
+        if (matchAttempts === 1) throw new Error("Network connection lost.");
+
+        return Response.json({
+          name: "example",
+          time: {},
+        });
+      },
+    } as unknown as Cache;
+
+    globalThis.caches = {
+      async open() {
+        openAttempts += 1;
+        if (openAttempts === 1) throw new Error("Network connection lost.");
+        return cache;
+      },
+    } as unknown as CacheStorage;
+
+    let packageInfo = await getPackageInfo(context, "https://registry.npmjs.org", "example");
+
+    expect(packageInfo?.name).toBe("example");
+    expect(openAttempts).toBe(2);
+    expect(matchAttempts).toBe(2);
+  });
+});

--- a/packages/unpkg-worker/src/lib/npm-info.ts
+++ b/packages/unpkg-worker/src/lib/npm-info.ts
@@ -1,4 +1,4 @@
-import { createCacheableResponse } from "./cache-utils.ts";
+import { createCacheableResponse, waitUntilCachePut } from "./cache-utils.ts";
 
 export interface PackageInfo {
   description?: string;
@@ -63,7 +63,7 @@ export async function getPackageInfo(
     response = await fetch(request);
 
     if (response && response.ok) {
-      context.waitUntil(cache.put(request, createCacheableResponse(response)));
+      waitUntilCachePut(context, cache, request, createCacheableResponse(response), "npm-info");
     }
   }
 

--- a/packages/unpkg-worker/src/lib/npm-info.ts
+++ b/packages/unpkg-worker/src/lib/npm-info.ts
@@ -1,4 +1,10 @@
-import { createCacheableResponse, waitUntilCachePut } from "./cache-utils.ts";
+import {
+  createCacheableResponse,
+  readOptionalResponseWithNetworkRetry,
+  readResponseWithNetworkRetry,
+  retryOnNetworkConnectionLost,
+  waitUntilCachePut,
+} from "./cache-utils.ts";
 
 export interface PackageInfo {
   description?: string;
@@ -56,19 +62,25 @@ export async function getPackageInfo(
     headers: { Accept: "application/json" },
   });
 
-  let cache = await caches.open("npm-info");
-  let response = await cache.match(request);
+  let cache = await retryOnNetworkConnectionLost(() => caches.open("npm-info"));
+  let result = await readOptionalResponseWithNetworkRetry(() => cache.match(request));
 
-  if (!response) {
-    response = await fetch(request);
+  if (result == null) {
+    result = await readResponseWithNetworkRetry(() => fetch(request));
 
-    if (response && response.ok) {
-      waitUntilCachePut(context, cache, request, createCacheableResponse(response), "npm-info");
+    if (result.response.ok) {
+      waitUntilCachePut(
+        context,
+        cache,
+        request,
+        createCacheableResponse(result.response, result.body),
+        "npm-info"
+      );
     }
   }
 
-  if (response && response.ok) {
-    return response.json();
+  if (result.response.ok) {
+    return JSON.parse(new TextDecoder().decode(result.body)) as PackageInfo;
   }
 
   return null;

--- a/packages/unpkg-worker/src/unpkg-worker.ts
+++ b/packages/unpkg-worker/src/unpkg-worker.ts
@@ -18,3 +18,5 @@ export { getEsmPackageSubpath, normalizeEsmRequestUrl, parseEsmPackagePathname }
 
 export type { InlineRunnerOptions } from "./lib/inline-runner.ts";
 export { createInlineRunner } from "./lib/inline-runner.ts";
+
+export { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "./lib/cache-utils.ts";

--- a/packages/unpkg-worker/src/unpkg-worker.ts
+++ b/packages/unpkg-worker/src/unpkg-worker.ts
@@ -1,5 +1,6 @@
 export type { PackageFile, PackageFileMetadata, PackageFileListing } from "./lib/npm-files.ts";
-export { fetchFile, getFile, listFiles } from "./lib/npm-files.ts";
+export type { PackageFileResponse } from "./lib/npm-files.ts";
+export { fetchFile, fetchFileResponse, getFile, listFiles } from "./lib/npm-files.ts";
 
 export type { PackageInfo, PackageJson, ExportConditions, ExportTarget } from "./lib/npm-info.ts";
 export { getPackageInfo } from "./lib/npm-info.ts";
@@ -19,4 +20,12 @@ export { getEsmPackageSubpath, normalizeEsmRequestUrl, parseEsmPackagePathname }
 export type { InlineRunnerOptions } from "./lib/inline-runner.ts";
 export { createInlineRunner } from "./lib/inline-runner.ts";
 
-export { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "./lib/cache-utils.ts";
+export {
+  isCacheableResponse,
+  isNetworkConnectionLostError,
+  readOptionalResponseWithNetworkRetry,
+  readResponseWithNetworkRetry,
+  retryOnNetworkConnectionLost,
+  waitUntilCachePut,
+} from "./lib/cache-utils.ts";
+export type { BufferedResponse } from "./lib/cache-utils.ts";

--- a/packages/unpkg-www/src/request-handler.tsx
+++ b/packages/unpkg-www/src/request-handler.tsx
@@ -1,7 +1,7 @@
 import type { VNode } from "preact";
 import { render } from "preact-render-to-string";
 import {
-  fetchFile,
+  fetchFileResponse,
   createInlineRunner,
   getPackageInfo,
   listFiles,
@@ -202,16 +202,18 @@ export async function handleRequest(request: Request, env: Env, context: Executi
   let files = await listFiles(context, env.FILES_ORIGIN, packageName, version);
 
   if (filename != null && files.some((file) => file.path.toLowerCase() === filename.toLowerCase())) {
-    let response = await fetchFile(context, env.FILES_ORIGIN, packageName, version, filename);
+    let result = await fetchFileResponse(context, env.FILES_ORIGIN, packageName, version, filename);
 
-    if (response != null) {
+    if (result != null) {
+      let { body, response } = result;
+
       // In ?module requests, rewrite imports to unpkg.com/* URLs in JavaScript modules
       if (
         response.headers.has("Content-Type") &&
         response.headers.get("Content-Type")!.startsWith("text/javascript") &&
         url.searchParams.has("module")
       ) {
-        let code = new TextDecoder().decode(await response.arrayBuffer());
+        let code = new TextDecoder().decode(body);
         let deps = Object.assign({}, packageJson.peerDependencies, packageJson.dependencies);
         let newCode = rewriteImports(code, url.origin, deps);
 
@@ -243,8 +245,6 @@ export async function handleRequest(request: Request, env: Env, context: Executi
       headers.set("Access-Control-Allow-Origin", "*");
       headers.set("Access-Control-Expose-Headers", "*");
       headers.set("Cross-Origin-Resource-Policy", "cross-origin");
-
-      let body = await response.arrayBuffer();
 
       return withUtf8Charset(
         new Response(body, {

--- a/packages/unpkg-www/src/worker.test.ts
+++ b/packages/unpkg-www/src/worker.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import type { Env } from "./env.ts";
 import worker from "./worker.ts";
@@ -94,5 +94,25 @@ describe("worker", () => {
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe("/example@1.0.0");
     expect(cachedStatus).toBe(302);
+  });
+
+  it("returns a retryable 503 when the cache connection remains unavailable", async () => {
+    globalThis.caches = {
+      default: {
+        async match() {
+          throw new Error("Network connection lost.");
+        },
+      },
+    } as unknown as CacheStorage;
+    let error = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      let response = await worker.fetch(new Request("https://unpkg.com/example"), env, context);
+
+      expect(response.status).toBe(503);
+      expect(response.headers.get("Retry-After")).toBe("1");
+    } finally {
+      error.mockRestore();
+    }
   });
 });

--- a/packages/unpkg-www/src/worker.test.ts
+++ b/packages/unpkg-www/src/worker.test.ts
@@ -9,6 +9,16 @@ const context = {
   },
 } as unknown as ExecutionContext;
 
+const env: Env = {
+  APP_ORIGIN: "https://app.unpkg.com",
+  ASSETS_ORIGIN: "https://unpkg.com",
+  DEV: false,
+  ESM_ORIGIN: "https://esm.unpkg.com",
+  FILES_ORIGIN: "https://files.unpkg.com",
+  MODE: "test",
+  ORIGIN: "https://unpkg.com",
+};
+
 let originalCaches = globalThis.caches;
 
 afterEach(() => {
@@ -36,5 +46,53 @@ describe("worker", () => {
 
     expect(response.headers.get("Content-Type")).toBe("text/css; charset=utf-8");
     expect(await response.text()).toContain("×");
+  });
+
+  it("caches version redirect responses", async () => {
+    let cachedStatus: number | undefined;
+    let pending: Promise<unknown>[] = [];
+    let redirectContext = {
+      waitUntil(promise: Promise<unknown>) {
+        pending.push(promise);
+      },
+    } as unknown as ExecutionContext;
+
+    globalThis.caches = {
+      default: {
+        async match() {
+          return undefined;
+        },
+        async put(_request, response) {
+          cachedStatus = response.status;
+        },
+      },
+      async open(cacheName) {
+        expect(cacheName).toBe("npm-info");
+        return {
+          async match() {
+            return Response.json({
+              name: "example",
+              "dist-tags": { latest: "1.0.0" },
+              time: {},
+              versions: {
+                "1.0.0": {
+                  name: "example",
+                  version: "1.0.0",
+                  description: "Example package",
+                  dependencies: {},
+                },
+              },
+            });
+          },
+        };
+      },
+    } as unknown as CacheStorage;
+
+    let response = await worker.fetch(new Request("https://unpkg.com/example"), env, redirectContext);
+    await Promise.all(pending);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/example@1.0.0");
+    expect(cachedStatus).toBe(302);
   });
 });

--- a/packages/unpkg-www/src/worker.ts
+++ b/packages/unpkg-www/src/worker.ts
@@ -1,4 +1,9 @@
-import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "unpkg-worker";
+import {
+  isCacheableResponse,
+  isNetworkConnectionLostError,
+  retryOnNetworkConnectionLost,
+  waitUntilCachePut,
+} from "unpkg-worker";
 
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.tsx";
@@ -15,10 +20,7 @@ export default {
       let cacheMiss = response == null;
 
       if (!response) {
-        response =
-          request.method === "GET" || request.method === "HEAD"
-            ? await retryOnNetworkConnectionLost(() => handleRequest(request, env, context))
-            : await handleRequest(request, env, context);
+        response = await handleRequest(request, env, context);
       }
 
       response = withUtf8Charset(response);
@@ -38,6 +40,13 @@ export default {
       return response;
     } catch (error) {
       console.error(error);
+
+      if (isNetworkConnectionLostError(error)) {
+        return new Response("Service Unavailable", {
+          status: 503,
+          headers: { "Retry-After": "1" },
+        });
+      }
 
       return new Response("Internal Server Error", { status: 500 });
     }

--- a/packages/unpkg-www/src/worker.ts
+++ b/packages/unpkg-www/src/worker.ts
@@ -1,3 +1,5 @@
+import { isCacheableResponse, retryOnNetworkConnectionLost, waitUntilCachePut } from "unpkg-worker";
+
 import type { Env } from "./env.ts";
 import { handleRequest } from "./request-handler.tsx";
 import { withUtf8Charset } from "./response.ts";
@@ -9,11 +11,14 @@ export default {
       let cache = caches.default as Cache;
       let url = new URL(request.url);
       let shouldUseCache = url.pathname !== "/" && url.pathname !== "/index.html";
-      let response = shouldUseCache ? await cache.match(request) : undefined;
+      let response = shouldUseCache ? await retryOnNetworkConnectionLost(() => cache.match(request)) : undefined;
       let cacheMiss = response == null;
 
       if (!response) {
-        response = await handleRequest(request, env, context);
+        response =
+          request.method === "GET" || request.method === "HEAD"
+            ? await retryOnNetworkConnectionLost(() => handleRequest(request, env, context))
+            : await handleRequest(request, env, context);
       }
 
       response = withUtf8Charset(response);
@@ -21,11 +26,9 @@ export default {
       if (
         cacheMiss &&
         shouldUseCache &&
-        request.method === "GET" &&
-        response.status === 200 &&
-        response.headers.has("Cache-Control")
+        isCacheableResponse(request, response)
       ) {
-        context.waitUntil(cache.put(request, response.clone()));
+        waitUntilCachePut(context, cache, request, response.clone(), "unpkg-www");
       }
 
       if (request.method === "HEAD") {


### PR DESCRIPTION
Cloudflare production logs show `Network connection lost.` as the dominant Worker error. This handles those transient failures at the individual cache and GET boundaries across all three edge Workers without rerunning entire request pipelines.

- catches background `cache.put()` failures so optional cache work does not reject successful invocations, with cache-specific labels for follow-up observability
- retries default and named cache operations plus idempotent origin fetches once after a short jitter, including failures that occur while consuming response bodies
- reuses each buffered body for parsing, hashing, cache population, and final responses to avoid duplicate body-sized allocations
- returns `503 Service Unavailable` with `Retry-After: 1` when a connection remains unavailable after retry, while preserving generic 500 handling for application errors
- caches cache-controlled 301/302 responses, reducing repeated package metadata work for version and tag redirects
- preserves unexpected cache failures as error logs instead of silently swallowing them

Cloudflare documents `Network connection lost` as a transient fetch or binding failure that callers should catch and retry: https://developers.cloudflare.com/workers/observability/errors/#runtime-errors
