### PR TITLE
Fix wildcard export redirect loops

### DIFF
--- a/packages/unpkg-worker/src/lib/pkg-exports.ts
+++ b/packages/unpkg-worker/src/lib/pkg-exports.ts
@@ -2,8 +2,14 @@ import type { PackageJson, ExportConditions } from "./npm-info.ts";
 
 interface ResolvePackageExportOptions {
   conditions?: string[];
+  trace?: ResolvePackageExportTrace;
   useBrowserField?: boolean;
   useModuleField?: boolean;
+}
+
+interface ResolvePackageExportTrace {
+  usedBrowserField?: boolean;
+  usedCondition?: boolean;
 }
 
 export type PackageExportResolution =
@@ -42,6 +48,7 @@ export function resolvePackageExportResult(
   if (options?.useBrowserField) {
     // "browser": "./dist/index.js"
     if (typeof packageJson.browser === "string" && entry === ".") {
+      if (options.trace != null) options.trace.usedBrowserField = true;
       return resolved(pathToFilename(packageJson.browser));
     }
 
@@ -52,6 +59,7 @@ export function resolvePackageExportResult(
           let value = packageJson.browser[key];
 
           if (typeof value === "string") {
+            if (options.trace != null) options.trace.usedBrowserField = true;
             return resolved(pathToFilename(value));
           }
         }
@@ -82,7 +90,7 @@ export function resolvePackageExportResult(
   // "exports": { ... }
   if (typeof packageJson.exports === "object" && packageJson.exports != null) {
     let conditions = options?.conditions ?? ["unpkg", "default"];
-    let target = _resolveExportConditions(packageJson.exports, entry, conditions, entry === ".", null);
+    let target = _resolveExportConditions(packageJson.exports, entry, conditions, entry === ".", null, false, options?.trace);
     if (target === null) {
       return { status: "blocked" };
     }
@@ -135,7 +143,7 @@ export function resolveExportConditions(
   entry: string,
   supportedConditions: string[]
 ): string | null {
-  return _resolveExportConditions(exports, entry, supportedConditions, entry === ".", null) ?? null;
+  return _resolveExportConditions(exports, entry, supportedConditions, entry === ".", null, false) ?? null;
 }
 
 function _resolveExportConditions(
@@ -143,20 +151,24 @@ function _resolveExportConditions(
   entry: string,
   supportedConditions: string[],
   entryWasFound: boolean,
-  wildcardMatch: string | null
+  wildcardMatch: string | null,
+  conditionWasUsed: boolean,
+  trace?: ResolvePackageExportTrace
 ): string | null | undefined {
   for (let key in exports) {
     if (!isSubpath(key) || entry !== normalizeEntryPath(key)) continue;
 
     let value = exports[key];
     if (value === null) {
+      markConditionUsed(trace, conditionWasUsed);
       return null;
     }
     if (typeof value === "string") {
+      markConditionUsed(trace, conditionWasUsed);
       return applyWildcardMatch(value, wildcardMatch);
     }
 
-    return _resolveExportConditions(value, entry, supportedConditions, true, wildcardMatch);
+    return _resolveExportConditions(value, entry, supportedConditions, true, wildcardMatch, conditionWasUsed, trace);
   }
 
   let wildcardEntries = Object.entries(exports)
@@ -170,13 +182,15 @@ function _resolveExportConditions(
 
   for (let { match, value } of wildcardEntries) {
     if (value === null) {
+      markConditionUsed(trace, conditionWasUsed);
       return null;
     }
     if (typeof value === "string") {
+      markConditionUsed(trace, conditionWasUsed);
       return applyWildcardMatch(value, match);
     }
 
-    let resolved = _resolveExportConditions(value, entry, supportedConditions, true, match);
+    let resolved = _resolveExportConditions(value, entry, supportedConditions, true, match, conditionWasUsed, trace);
     if (resolved !== undefined) {
       return resolved;
     }
@@ -187,11 +201,17 @@ function _resolveExportConditions(
 
     if (!isSubpath(key) && supportedConditions.includes(key)) {
       if (value === null) {
-        if (entryWasFound) return null;
+        if (entryWasFound) {
+          markConditionUsed(trace, true);
+          return null;
+        }
       } else if (typeof value === "string") {
-        if (entryWasFound) return applyWildcardMatch(value, wildcardMatch);
+        if (entryWasFound) {
+          markConditionUsed(trace, true);
+          return applyWildcardMatch(value, wildcardMatch);
+        }
       } else {
-        let resolved = _resolveExportConditions(value, entry, supportedConditions, entryWasFound, wildcardMatch);
+        let resolved = _resolveExportConditions(value, entry, supportedConditions, entryWasFound, wildcardMatch, true, trace);
         if (resolved !== undefined) {
           return resolved;
         }
@@ -200,6 +220,10 @@ function _resolveExportConditions(
   }
 
   return undefined;
+}
+
+function markConditionUsed(trace: ResolvePackageExportTrace | undefined, conditionWasUsed: boolean): void {
+  if (trace != null && conditionWasUsed) trace.usedCondition = true;
 }
 
 function matchWildcardExport(pattern: string, entry: string): string | null {

--- a/packages/unpkg-www/src/request-handler.test.ts
+++ b/packages/unpkg-www/src/request-handler.test.ts
@@ -36,6 +36,43 @@ const cesiumPackageInfo = {
   },
 };
 
+const mqttPackageInfo = {
+  name: "mqtt",
+  "dist-tags": { latest: "5.15.2" },
+  versions: {
+    "5.15.2": {
+      name: "mqtt",
+      version: "5.15.2",
+      browser: {
+        "./server.js": "./client.js",
+      },
+      exports: {
+        ".": "./build/index.js",
+        "./alias": "./intermediate.js",
+        "./bar": "./foo",
+        "./foo": "./missing.js",
+        "./intermediate.js": "./final.js",
+        "./legacy": "./missing-target.mjs",
+        "./conditional.js": {
+          browser: "./browser.js",
+          default: "./conditional.js",
+        },
+        "./conditional-wildcard": {
+          browser: "./dist/mqtt.min.js",
+          default: "./dist/mqtt.min.js",
+        },
+        "./conditional-server": {
+          foo: "./server.js",
+        },
+        "./dist/*": "./dist/*.js",
+        "./object-dist/*": {
+          default: "./object-dist/*.js",
+        },
+      },
+    },
+  },
+};
+
 function dispatchFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   let request = input instanceof Request ? input : new Request(input, init);
   return handleRequest(request, env, context);
@@ -43,6 +80,15 @@ function dispatchFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Re
 
 function fileResponse(path: string): Response {
   return new Response(Bun.file(path));
+}
+
+function fileMetadata(path: string) {
+  return {
+    path,
+    size: 0,
+    type: "text/javascript",
+    integrity: "sha256-dGVzdA==",
+  };
 }
 
 describe("handleRequest", () => {
@@ -92,6 +138,66 @@ describe("handleRequest", () => {
             },
           });
         }
+        if (url.pathname === "/list/mqtt@5.15.2/") {
+          return Response.json({
+            package: "mqtt",
+            version: "5.15.2",
+            prefix: "/",
+            files: [
+              "/bar",
+              "/browser.js",
+              "/build/index.js",
+              "/client.js",
+              "/conditional.js",
+              "/dist/mqtt.min.js",
+              "/final.js",
+              "/intermediate.js",
+              "/legacy.js",
+              "/object-dist/example.js",
+              "/server.js",
+            ].map(fileMetadata),
+          });
+        }
+        if (url.pathname === "/file/mqtt@5.15.2/dist/mqtt.min.js") {
+          return new Response("export const mqtt = {};", {
+            headers: {
+              "Content-Digest": "sha256=:dGVzdA==:",
+              "Content-Type": "text/javascript",
+            },
+          });
+        }
+        if (url.pathname === "/file/mqtt@5.15.2/intermediate.js") {
+          return new Response("export const intermediate = {};", {
+            headers: {
+              "Content-Digest": "sha256=:dGVzdA==:",
+              "Content-Type": "text/javascript",
+            },
+          });
+        }
+        if (url.pathname === "/file/mqtt@5.15.2/object-dist/example.js") {
+          return new Response("export const example = {};", {
+            headers: {
+              "Content-Digest": "sha256=:dGVzdA==:",
+              "Content-Type": "text/javascript",
+            },
+          });
+        }
+        if (url.pathname === "/list/react@19.0.0/") {
+          return Response.json({
+            package: "react",
+            version: "19.0.0",
+            prefix: "/",
+            files: [fileMetadata("/compiler-runtime.js")],
+          });
+        }
+        if (url.pathname === "/list/preact@10.25.4/") {
+          return Response.json({
+            package: "preact",
+            version: "10.25.4",
+            prefix: "/",
+            files: [fileMetadata("/hooks/dist/hooks.mjs")],
+          });
+        }
 
         // Run the request through the file server. This allows us to write integration tests
         // that run without booting the file server.
@@ -103,6 +209,8 @@ describe("handleRequest", () => {
           return Response.json(cesiumPackageInfo);
         case "https://registry.npmjs.org/lodash":
           return fileResponse(packageInfo.lodash);
+        case "https://registry.npmjs.org/mqtt":
+          return Response.json(mqttPackageInfo);
         case "https://registry.npmjs.org/preact":
           return fileResponse(packageInfo.preact);
         case "https://registry.npmjs.org/react":
@@ -256,6 +364,155 @@ describe("handleRequest", () => {
       expect(await response.text()).toBe("export const Cesium = {};");
     });
 
+    it("serves physical files that also match wildcard export subpaths", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/dist/mqtt.min.js?cache-bust", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Location")).toBeNull();
+      expect(await response.text()).toBe("export const mqtt = {};");
+    });
+
+    it("serves physical files that match default conditional wildcard exports", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/object-dist/example.js", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Location")).toBeNull();
+      expect(await response.text()).toBe("export const example = {};");
+    });
+
+    it("pins unversioned physical wildcard export targets without changing the filename", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt/dist/mqtt.min.js?cache-bust", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toBe("/mqtt@5.15.2/dist/mqtt.min.js?cache-bust");
+
+      let pinnedResponse = await dispatchFetch(
+        new URL(response.headers.get("Location")!, "https://unpkg.com"),
+        { redirect: "manual" },
+      );
+      expect(pinnedResponse.status).toBe(200);
+      expect(pinnedResponse.headers.get("Location")).toBeNull();
+    });
+
+    it("resolves wildcard export subpaths once and then serves their physical target", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt/dist/mqtt.min", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toBe("/mqtt@5.15.2/dist/mqtt.min.js");
+
+      let targetResponse = await dispatchFetch(
+        new URL(response.headers.get("Location")!, "https://unpkg.com"),
+        { redirect: "manual" },
+      );
+      expect(targetResponse.status).toBe(200);
+      expect(targetResponse.headers.get("Location")).toBeNull();
+    });
+
+    it("serves the first physical target in a finite export chain", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/alias", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(301);
+      expect(response.headers.get("Location")).toBe("/mqtt@5.15.2/intermediate.js");
+
+      let targetResponse = await dispatchFetch(
+        new URL(response.headers.get("Location")!, "https://unpkg.com"),
+        { redirect: "manual" },
+      );
+      expect(targetResponse.status).toBe(200);
+      expect(targetResponse.headers.get("Location")).toBeNull();
+      expect(await targetResponse.text()).toBe("export const intermediate = {};");
+    });
+
+    it("honors explicit browser mappings for physical files", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/server.js?browser", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(301);
+      expect(response.headers.get("Location")).toBe("/mqtt@5.15.2/client.js");
+    });
+
+    it("honors explicit export conditions for physical files", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/conditional.js?conditions=browser", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(301);
+      expect(response.headers.get("Location")).toBe("/mqtt@5.15.2/browser.js");
+    });
+
+    it("does not re-resolve conditional targets that match wildcard exports", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/conditional-wildcard?conditions=browser", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(301);
+      expect(response.headers.get("Location")).toBe("/mqtt@5.15.2/dist/mqtt.min.js");
+
+      let targetResponse = await dispatchFetch(
+        new URL(response.headers.get("Location")!, "https://unpkg.com"),
+        { redirect: "manual" },
+      );
+      expect(targetResponse.status).toBe(200);
+      expect(targetResponse.headers.get("Location")).toBeNull();
+    });
+
+    it("does not carry unused resolver flags onto physical targets", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/conditional-server?conditions=foo&browser", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(301);
+      expect(response.headers.get("Location")).toBe("/mqtt@5.15.2/server.js");
+    });
+
+    it("serves physical predecessors at stale redirect targets", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/dist/mqtt.min.js.js", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Location")).toBeNull();
+      expect(await response.text()).toBe("export const mqtt = {};");
+    });
+
+    it("does not recover arbitrary reverse export mappings", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/foo", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Location")).toBeNull();
+    });
+
+    it("does not redirect repeatedly when a wildcard export target is missing", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/dist/missing", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Location")).toBeNull();
+    });
+
+    it("does not use legacy resolution when an export target is missing", async () => {
+      let response = await dispatchFetch("https://unpkg.com/mqtt@5.15.2/legacy", {
+        redirect: "manual",
+      });
+
+      expect(response.status).toBe(404);
+      expect(response.headers.get("Location")).toBeNull();
+    });
+
     it("resolves npm tag and filename in a single redirect", async () => {
       let response = await dispatchFetch("https://unpkg.com/react@latest", { redirect: "manual" });
       expect(response.status).toBe(302);
@@ -293,7 +550,7 @@ describe("handleRequest", () => {
       expect(response.status).toBe(301);
       let location = response.headers.get("Location");
       expect(location).not.toBeNull();
-      expect(location).toBe("/react@19.0.0/index.js?conditions=default");
+      expect(location).toBe("/react@19.0.0/index.js");
     });
 
     it('resolves using "exports" field and a custom condition in package.json', async () => {
@@ -303,7 +560,7 @@ describe("handleRequest", () => {
       expect(response.status).toBe(301);
       let location = response.headers.get("Location");
       expect(location).not.toBeNull();
-      expect(location).toBe("/react@19.0.0/react.react-server.js?conditions=react-server");
+      expect(location).toBe("/react@19.0.0/react.react-server.js");
     });
 
     it('resolves using a custom filename with "exports" field in package.json', async () => {
@@ -321,7 +578,7 @@ describe("handleRequest", () => {
       expect(response.status).toBe(301);
       let location = response.headers.get("Location");
       expect(location).not.toBeNull();
-      expect(location).toBe("/preact@10.25.4/hooks/dist/hooks.mjs?conditions=import");
+      expect(location).toBe("/preact@10.25.4/hooks/dist/hooks.mjs");
     });
 
     it('resolves to "main" when "exports" field has no "default" condition', async () => {
@@ -387,7 +644,7 @@ describe("handleRequest", () => {
       expect(response.status).toBe(301);
       let location = response.headers.get("Location");
       expect(location).not.toBeNull();
-      expect(location).toBe("/preact@10.25.4/dist/preact.module.js?conditions=browser");
+      expect(location).toBe("/preact@10.25.4/dist/preact.module.js");
     });
   });
 

--- a/packages/unpkg-www/src/request-handler.tsx
+++ b/packages/unpkg-www/src/request-handler.tsx
@@ -156,15 +156,89 @@ export async function handleRequest(request: Request, env: Env, context: Executi
   let wantsBrowser = url.searchParams.has("browser");
   let wantsModule = url.searchParams.has("module");
 
-  let resolvedFilename = resolvePackageExport(packageJson, filename ?? "/", {
+  let resolutionTrace: { usedBrowserField?: boolean; usedCondition?: boolean } = {};
+  let resolveOptions = {
     useBrowserField: wantsBrowser,
     useModuleField: wantsModule,
     conditions,
-  });
+    trace: resolutionTrace,
+  };
+  let resolvedFilename = resolvePackageExport(packageJson, filename ?? "/", resolveOptions);
+  let usedExplicitCondition = conditions != null && resolutionTrace.usedCondition === true;
+  let usesExplicitExportMapping = resolutionTrace.usedBrowserField === true || usedExplicitCondition;
+
+  // Export targets are physical package files, so they must not be fed back through
+  // package export resolution after a redirect. When an explicit request matches an
+  // export, use the file listing to distinguish a real file from an export subpath.
+  let files = filename != null && resolvedFilename != null && resolvedFilename !== filename
+    ? await listFiles(context, env.FILES_ORIGIN, packageName, version)
+    : undefined;
+
+  if (files != null && resolvedFilename != null && filename != null) {
+    let requestedFilename = filename;
+    let resolvedTargetFilename = resolvedFilename;
+    let requestedFile = files.find(
+      (file) => file.path.toLowerCase() === requestedFilename.toLowerCase(),
+    );
+    let resolvedFile = files.find(
+      (file) => file.path.toLowerCase() === resolvedTargetFilename.toLowerCase(),
+    );
+
+    if (requestedFile != null && !usesExplicitExportMapping) {
+      // The request already names the physical export target. Serve it directly.
+      resolvedFilename = filename;
+    } else if (resolvedFile == null) {
+      if (version !== parsed.version) {
+        // Pin the original request before deciding how to handle a missing target.
+        return redirect(`/${packageName}@${version}${requestedFilename}${url.search}`, {
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Cache-Control": "public, max-age=60, s-maxage=300",
+            "Cross-Origin-Resource-Policy": "cross-origin",
+          },
+        });
+      }
+
+      // A bad permanent redirect that repeatedly appended a suffix may already be
+      // cached by clients. Recover only that exact shape: X -> X+suffix ->
+      // X+suffix+suffix. Broader reverse export lookup is ambiguous and could serve
+      // the wrong physical file for a legitimate export subpath.
+      let appendedSuffix = !usesExplicitExportMapping && resolvedTargetFilename.startsWith(requestedFilename)
+        ? resolvedTargetFilename.slice(requestedFilename.length)
+        : "";
+      let predecessorPath =
+        appendedSuffix !== "" && requestedFilename.endsWith(appendedSuffix)
+          ? requestedFilename.slice(0, -appendedSuffix.length)
+          : null;
+      let predecessorFiles =
+        predecessorPath == null
+          ? []
+          : files.filter((file) => file.path.toLowerCase() === predecessorPath.toLowerCase());
+      let predecessorFile = predecessorFiles.length === 1 ? predecessorFiles[0] : undefined;
+
+      if (
+        predecessorFile == null ||
+        resolvePackageExport(packageJson, predecessorFile.path, resolveOptions) !== requestedFilename
+      ) {
+        return notFound(`Not found: ${url.pathname}${url.search}`);
+      }
+
+      filename = predecessorFile.path;
+      resolvedFilename = filename;
+    }
+  }
 
   // If the resolved filename is different from the original filename, redirect to the new URL
   if (resolvedFilename != null && resolvedFilename !== filename) {
-    let location = `/${packageName}@${version}${resolvedFilename}${url.search}`;
+    let redirectSearchParams = new URLSearchParams(url.search);
+    // Browser and condition selectors resolve the logical subpath. Do not carry
+    // either one onto the physical target where an initially unused selector could
+    // become active and resolve the target again. `module` remains because it also
+    // controls import rewriting when the physical file is served.
+    redirectSearchParams.delete("browser");
+    redirectSearchParams.delete("conditions");
+    let redirectSearch = redirectSearchParams.size === 0 ? "" : `?${redirectSearchParams}`;
+    let location = `/${packageName}@${version}${resolvedFilename}${redirectSearch}`;
 
     // If the version number is already resolved, we can issue a permanent redirect (301)
     if (version === parsed.version) {
@@ -199,7 +273,7 @@ export async function handleRequest(request: Request, env: Env, context: Executi
     });
   }
 
-  let files = await listFiles(context, env.FILES_ORIGIN, packageName, version);
+  files ??= await listFiles(context, env.FILES_ORIGIN, packageName, version);
 
   if (filename != null && files.some((file) => file.path.toLowerCase() === filename.toLowerCase())) {
     let response = await fetchFile(context, env.FILES_ORIGIN, packageName, version, filename);


### PR DESCRIPTION
Fixes #489.

Wildcard package export targets were being fed back through export resolution after redirecting to their physical file. For mappings such as `"./dist/*": "./dist/*.js"`, this repeatedly appended `.js` and produced an infinite redirect loop.

- distinguish logical export subpaths from published physical files before redirecting
- validate resolved targets and avoid falling through to unrelated legacy file resolution
- trace and consume browser/condition selectors once while preserving module rewriting
- safely serve the predecessor file for already-cached suffix-appending redirects
- cover versioned, unversioned, conditional, finite-chain, missing-target, and stale-redirect cases
