### PR TITLE
Fit version selector to selected version

### DIFF
--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -20,6 +20,19 @@
   color-scheme: light dark;
 }
 
+.version-selector {
+  width: 7rem;
+  max-width: min(24rem, 45vw);
+}
+
+@supports (field-sizing: content) {
+  .version-selector {
+    field-sizing: content;
+    width: auto;
+    min-width: 5rem;
+  }
+}
+
 @media (prefers-color-scheme: dark) {
   .inline-link {
     text-decoration-line: underline;

--- a/packages/unpkg-app/assets/styles.css
+++ b/packages/unpkg-app/assets/styles.css
@@ -22,7 +22,7 @@
 
 .version-selector {
   width: 7rem;
-  max-width: min(24rem, 45vw);
+  max-width: min(18rem, 45vw);
 }
 
 @supports (field-sizing: content) {

--- a/packages/unpkg-app/src/components/files-header.tsx
+++ b/packages/unpkg-app/src/components/files-header.tsx
@@ -56,7 +56,7 @@ export function FilesHeader({
       <div class="mb-6 flex justify-between items-center">
         <h1 class="text-black dark:text-dark-foreground text-3xl leading-tight font-semibold">{packageInfo.name}</h1>
 
-        <div class="text-right w-48">
+        <div class="ml-4 shrink-0 text-right">
           <span>Version: </span>
           <Hydrate container={<span />}>
             <VersionSelector
@@ -64,7 +64,7 @@ export function FilesHeader({
               availableVersions={availableVersions}
               currentVersion={version}
               pathnameFormat={pathnameFormat}
-              class="w-28 p-1 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-chrome text-sm"
+              class="version-selector p-1 border border-slate-300 dark:border-dark-border bg-slate-100 dark:bg-dark-chrome text-sm"
             />
           </Hydrate>
         </div>

--- a/packages/unpkg-app/src/request-handler.test.ts
+++ b/packages/unpkg-app/src/request-handler.test.ts
@@ -132,6 +132,13 @@ describe("handleRequest", () => {
     expect(html).toContain("inline-link");
   });
 
+  it("renders a content-sized version selector", async () => {
+    let response = await dispatchFetch("https://app.unpkg.com/react@18.2.0");
+    let html = await response.text();
+
+    expect(html).toContain('class="version-selector ');
+  });
+
   it("does not fetch the body of a text file that is too large to preview", async () => {
     let response = await dispatchFetch("https://app.unpkg.com/react@18.2.0/files/large.txt");
     let html = await response.text();


### PR DESCRIPTION
The app file browser currently gives every version selector a fixed width, which clips longer prerelease versions and leaves unnecessary space around short versions.

- Size supported browsers to the currently displayed option with `field-sizing: content`
- Keep the existing 7rem width as a fallback for older browsers
- Bound the responsive width between 5rem and the smaller of 18rem or 45vw
- Let the header control shrink-wrap the selector instead of reserving a fixed-width column

```css
/* Before */
.version-selector { width: 7rem; }

/* After, in supporting browsers */
.version-selector {
  field-sizing: content;
  min-width: 5rem;
  max-width: min(18rem, 45vw);
}
```
