### PR TITLE
Fix dark mode code line highlights

### DIFF
--- a/packages/unpkg-app/assets/code-dark.css
+++ b/packages/unpkg-app/assets/code-dark.css
@@ -1,6 +1,8 @@
 .hljs-dark-listing {
-  background: var(--color-dark-code);
   color: #d5ced9;
+}
+.hljs-frame {
+  background: var(--color-dark-code);
 }
 .hljs-frame,
 .hljs-frame > * {


### PR DESCRIPTION
Selected lines in code listings were only visibly highlighted in the gutter in dark mode because the opaque code-pane background covered the full-width highlight layer. This moves that background to the shared listing frame so the existing selection layer remains visible across the row.

- Restores full-width selected-line highlights in dark mode
- Preserves the existing syntax colors, gutter styling, and light-mode behavior
