### PR TITLE
Only show the demo button's running state on slow runs

### DIFF
--- a/packages/unpkg-www/src/components/run-demo.tsx
+++ b/packages/unpkg-www/src/components/run-demo.tsx
@@ -8,6 +8,9 @@ confetti({ particleCount: 80, spread: 70 });`;
 
 export function RunDemo({ runUrl }: { runUrl: string }): VNode {
   let [state, setState] = useState<"idle" | "running" | "error">("idle");
+  // Warm runs finish in a few milliseconds; only show the running state when a
+  // run is actually slow, so the label doesn't flicker on every click.
+  let [slowRun, setSlowRun] = useState(false);
   let containerRef = useRef<HTMLDivElement>(null);
 
   async function runExample() {
@@ -17,6 +20,7 @@ export function RunDemo({ runUrl }: { runUrl: string }): VNode {
     }
 
     setState("running");
+    let slowRunTimer = setTimeout(() => setSlowRun(true), 250);
 
     try {
       // Recreate the example's inline script tag and hand it to the real /run
@@ -36,6 +40,9 @@ export function RunDemo({ runUrl }: { runUrl: string }): VNode {
     } catch (error) {
       console.error(error);
       setState("error");
+    } finally {
+      clearTimeout(slowRunTimer);
+      setSlowRun(false);
     }
   }
 
@@ -43,11 +50,21 @@ export function RunDemo({ runUrl }: { runUrl: string }): VNode {
     <div class="mt-3 flex items-center gap-4">
       <button
         type="button"
-        class="px-4 py-2 text-sm font-semibold border border-slate-300 dark:border-dark-border-strong bg-slate-100 dark:bg-dark-panel hover:bg-slate-200 dark:hover:bg-dark-border cursor-pointer disabled:opacity-50 disabled:cursor-default"
+        class={`px-4 py-2 text-sm font-semibold border border-slate-300 dark:border-dark-border-strong bg-slate-100 dark:bg-dark-panel ${
+          slowRun
+            ? "opacity-50 cursor-default"
+            : "hover:bg-slate-200 dark:hover:bg-dark-border cursor-pointer"
+        }`}
         disabled={state === "running"}
         onClick={runExample}
       >
-        {state === "running" ? "Running…" : "Run this example"}
+        {/* Reserve the wider label's width so the swap never resizes the button. */}
+        <span class="grid">
+          <span class="col-start-1 row-start-1 invisible" aria-hidden="true">
+            Run this example
+          </span>
+          <span class="col-start-1 row-start-1">{slowRun ? "Running…" : "Run this example"}</span>
+        </span>
       </button>
       {state === "error" && (
         <span class="text-sm text-red-600 dark:text-red-400">The example failed to run — see the console.</span>


### PR DESCRIPTION
The homepage confetti demo's button flashed its Running… label on every click because warm runs complete in a few milliseconds. Standard delayed-indicator fix: the running state (label + dimming) only appears when a run exceeds 250ms, and the button reserves the wider label's width so the swap never changes its size. Fast clicks now change nothing visually; cold first clicks still show feedback.